### PR TITLE
feat: 실시간 채팅·알림·신뢰등급·노쇼 신고 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,23 @@
 *.ear
 .DS_Store
 Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# Backend
+backend/build/
+backend/.gradle/
+backend/data/
+backend/src/main/resources/application-local.yml
+
+# Frontend
+frontend/node_modules/
+frontend/dist/
+frontend/.env
+
+# Env & secrets
+.env
+.env.local

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
@@ -34,6 +35,9 @@ dependencies {
 
     // PostgreSQL (Supabase)
     runtimeOnly 'org.postgresql:postgresql'
+
+    // Local dev (profile: h2)
+    runtimeOnly 'com.h2database:h2'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/yonta/config/SecurityConfig.java
+++ b/backend/src/main/java/com/yonta/config/SecurityConfig.java
@@ -30,6 +30,8 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/auth/**",
                     "/api/parties/**",
+                    "/api/notifications/**",
+                    "/api/users/me/**",
                     "/api/time-slots/**",
                     "/api/admin/**",
                     "/h2-console/**",
@@ -49,7 +51,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:5173"));
+        config.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:3001", "http://localhost:5173"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);

--- a/backend/src/main/java/com/yonta/config/WebConfig.java
+++ b/backend/src/main/java/com/yonta/config/WebConfig.java
@@ -16,7 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("http://localhost:3000", "http://localhost:5173")
+                .allowedOrigins("http://localhost:3000", "http://localhost:3001", "http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/backend/src/main/java/com/yonta/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/yonta/config/WebSocketConfig.java
@@ -1,0 +1,42 @@
+package com.yonta.config;
+
+import com.yonta.security.JwtTokenProvider;
+import com.yonta.security.StompAuthChannelInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic", "/queue");
+        registry.setApplicationDestinationPrefixes("/app");
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOrigins(
+                        "http://localhost:3000",
+                        "http://localhost:3001",
+                        "http://localhost:5173"
+                )
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}

--- a/backend/src/main/java/com/yonta/controller/NotificationController.java
+++ b/backend/src/main/java/com/yonta/controller/NotificationController.java
@@ -1,0 +1,66 @@
+package com.yonta.controller;
+
+import com.yonta.dto.response.ApiResponse;
+import com.yonta.dto.response.NotificationResponse;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.security.JwtTokenProvider;
+import com.yonta.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<NotificationResponse>>> getMyNotifications(
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        return ResponseEntity.ok(ApiResponse.ok(notificationService.getMyNotifications(userId)));
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<ApiResponse<Map<String, Long>>> getUnreadCount(
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        long count = notificationService.getUnreadCount(userId);
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("count", count)));
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<ApiResponse<Void>> markAsRead(
+            @PathVariable Long id,
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        notificationService.markAsRead(userId, id);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<ApiResponse<Void>> markAllAsRead(
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        notificationService.markAllAsRead(userId);
+        return ResponseEntity.ok(ApiResponse.ok(null));
+    }
+
+    private Long extractRequiredUserId(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        String token = authHeader.replace("Bearer ", "");
+        if (!jwtTokenProvider.validate(token)) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        return jwtTokenProvider.getUserId(token);
+    }
+}

--- a/backend/src/main/java/com/yonta/controller/PartyChatController.java
+++ b/backend/src/main/java/com/yonta/controller/PartyChatController.java
@@ -1,0 +1,54 @@
+package com.yonta.controller;
+
+import com.yonta.dto.request.ChatMessageRequest;
+import com.yonta.dto.response.ApiResponse;
+import com.yonta.dto.response.ChatMessageResponse;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.security.JwtTokenProvider;
+import com.yonta.service.PartyChatService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/parties/{partyId}/messages")
+@RequiredArgsConstructor
+public class PartyChatController {
+
+    private final PartyChatService partyChatService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<ChatMessageResponse>>> getMessages(
+            @PathVariable Long partyId,
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        List<ChatMessageResponse> messages = partyChatService.getMessages(partyId, userId);
+        return ResponseEntity.ok(ApiResponse.ok(messages));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatMessageResponse>> sendMessage(
+            @PathVariable Long partyId,
+            @Valid @RequestBody ChatMessageRequest request,
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractRequiredUserId(authHeader);
+        ChatMessageResponse sent = partyChatService.sendMessage(partyId, userId, request.getContent());
+        return ResponseEntity.ok(ApiResponse.ok(sent));
+    }
+
+    private Long extractRequiredUserId(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        String token = authHeader.replace("Bearer ", "");
+        if (!jwtTokenProvider.validate(token)) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        return jwtTokenProvider.getUserId(token);
+    }
+}

--- a/backend/src/main/java/com/yonta/controller/PartyChatStompController.java
+++ b/backend/src/main/java/com/yonta/controller/PartyChatStompController.java
@@ -1,0 +1,34 @@
+package com.yonta.controller;
+
+import com.yonta.dto.request.ChatMessageRequest;
+import com.yonta.service.PartyChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class PartyChatStompController {
+
+    private final PartyChatService partyChatService;
+
+    @MessageMapping("/party.{partyId}.chat")
+    public void sendChatMessage(
+            @DestinationVariable Long partyId,
+            @Payload ChatMessageRequest request,
+            SimpMessageHeaderAccessor headerAccessor) {
+        Long userId = extractUserId(headerAccessor);
+        partyChatService.sendMessage(partyId, userId, request.getContent());
+    }
+
+    private Long extractUserId(SimpMessageHeaderAccessor accessor) {
+        if (accessor.getUser() instanceof Authentication auth) {
+            return (Long) auth.getPrincipal();
+        }
+        throw new IllegalArgumentException("인증되지 않은 WebSocket 연결입니다.");
+    }
+}

--- a/backend/src/main/java/com/yonta/controller/TrustController.java
+++ b/backend/src/main/java/com/yonta/controller/TrustController.java
@@ -1,0 +1,59 @@
+package com.yonta.controller;
+
+import com.yonta.dto.request.MemberReviewRequest;
+import com.yonta.dto.request.NoShowReportRequest;
+import com.yonta.dto.response.*;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.security.JwtTokenProvider;
+import com.yonta.service.TrustService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TrustController {
+
+    private final TrustService trustService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @GetMapping("/api/users/me/dashboard")
+    public ResponseEntity<ApiResponse<TrustDashboardResponse>> getDashboard(
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractUserId(authHeader);
+        return ResponseEntity.ok(ApiResponse.ok(trustService.getDashboard(userId)));
+    }
+
+    @PostMapping("/api/parties/{partyId}/member-reviews")
+    public ResponseEntity<ApiResponse<MemberReviewResponse>> submitMemberReview(
+            @PathVariable Long partyId,
+            @Valid @RequestBody MemberReviewRequest request,
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractUserId(authHeader);
+        MemberReviewResponse result = trustService.submitMemberReview(partyId, userId, request);
+        return ResponseEntity.ok(ApiResponse.ok(result, "멤버 평가가 저장되었습니다."));
+    }
+
+    @PostMapping("/api/parties/{partyId}/no-show-reports")
+    public ResponseEntity<ApiResponse<NoShowReportResponse>> submitNoShowReport(
+            @PathVariable Long partyId,
+            @Valid @RequestBody NoShowReportRequest request,
+            @RequestHeader("Authorization") String authHeader) {
+        Long userId = extractUserId(authHeader);
+        NoShowReportResponse result = trustService.submitNoShowReport(partyId, userId, request);
+        return ResponseEntity.ok(ApiResponse.ok(result, result.getMessage()));
+    }
+
+    private Long extractUserId(String authHeader) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        String token = authHeader.replace("Bearer ", "");
+        if (!jwtTokenProvider.validate(token)) {
+            throw new CustomException(ErrorCode.INVALID_AUTH_HEADER);
+        }
+        return jwtTokenProvider.getUserId(token);
+    }
+}

--- a/backend/src/main/java/com/yonta/domain/MemberReview.java
+++ b/backend/src/main/java/com/yonta/domain/MemberReview.java
@@ -1,0 +1,48 @@
+package com.yonta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "member_review",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"taxi_party_id", "reviewer_id", "reviewee_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberReview extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taxi_party_id", nullable = false)
+    private TaxiParty taxiParty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private User reviewee;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(length = 300)
+    private String comment;
+
+    @Builder
+    public MemberReview(TaxiParty taxiParty, User reviewer, User reviewee, int rating, String comment) {
+        if (reviewer.getId().equals(reviewee.getId())) {
+            throw new IllegalArgumentException("본인은 평가할 수 없습니다.");
+        }
+        this.taxiParty = taxiParty;
+        this.reviewer = reviewer;
+        this.reviewee = reviewee;
+        this.rating = rating;
+        this.comment = comment;
+    }
+}

--- a/backend/src/main/java/com/yonta/domain/NoShowReport.java
+++ b/backend/src/main/java/com/yonta/domain/NoShowReport.java
@@ -1,0 +1,53 @@
+package com.yonta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "no_show_report",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"taxi_party_id", "reporter_id", "reported_user_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NoShowReport extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taxi_party_id", nullable = false)
+    private TaxiParty taxiParty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    @Column(nullable = false, length = 500)
+    private String reason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NoShowReportStatus status;
+
+    @Builder
+    public NoShowReport(TaxiParty taxiParty, User reporter, User reportedUser, String reason) {
+        if (reporter.getId().equals(reportedUser.getId())) {
+            throw new IllegalArgumentException("본인은 신고할 수 없습니다.");
+        }
+        this.taxiParty = taxiParty;
+        this.reporter = reporter;
+        this.reportedUser = reportedUser;
+        this.reason = reason.trim();
+        this.status = NoShowReportStatus.PENDING;
+    }
+
+    public void confirm() {
+        this.status = NoShowReportStatus.CONFIRMED;
+    }
+}

--- a/backend/src/main/java/com/yonta/domain/NoShowReportStatus.java
+++ b/backend/src/main/java/com/yonta/domain/NoShowReportStatus.java
@@ -1,0 +1,13 @@
+package com.yonta.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoShowReportStatus {
+    PENDING("검토중"),
+    CONFIRMED("확정");
+
+    private final String label;
+}

--- a/backend/src/main/java/com/yonta/domain/NotificationType.java
+++ b/backend/src/main/java/com/yonta/domain/NotificationType.java
@@ -1,0 +1,16 @@
+package com.yonta.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationType {
+    MEMBER_JOINED("파티 참여"),
+    MEMBER_LEFT("파티 탈퇴"),
+    DEPARTURE_SOON("출발 임박"),
+    PARTY_DEPARTED("출발 완료"),
+    PARTY_SETTLED("파티 종료");
+
+    private final String label;
+}

--- a/backend/src/main/java/com/yonta/domain/PartyMessage.java
+++ b/backend/src/main/java/com/yonta/domain/PartyMessage.java
@@ -1,0 +1,41 @@
+package com.yonta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "party_message", indexes = {
+        @Index(name = "idx_party_message_party_created", columnList = "taxi_party_id, created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PartyMessage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taxi_party_id", nullable = false)
+    private TaxiParty taxiParty;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User sender;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Builder
+    public PartyMessage(TaxiParty taxiParty, User sender, String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("메시지 내용이 비어 있습니다.");
+        }
+        if (content.length() > 500) {
+            throw new IllegalArgumentException("메시지는 500자 이하여야 합니다.");
+        }
+        this.taxiParty = taxiParty;
+        this.sender = sender;
+        this.content = content.trim();
+    }
+}

--- a/backend/src/main/java/com/yonta/domain/User.java
+++ b/backend/src/main/java/com/yonta/domain/User.java
@@ -39,6 +39,12 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, length = 10)
     private Role role;
 
+    @Column(nullable = false)
+    private int noShowCount;
+
+    @Column
+    private java.time.LocalDateTime suspendedUntil;
+
     @Builder
     public User(String studentId, String name, String email, String password, Gender gender) {
         this.studentId = studentId;
@@ -49,6 +55,7 @@ public class User extends BaseTimeEntity {
         this.mannerTemp = 36.5;
         this.verified = false;
         this.role = Role.USER;
+        this.noShowCount = 0;
     }
 
     public void verify() {
@@ -57,6 +64,18 @@ public class User extends BaseTimeEntity {
 
     public void updateMannerTemp(double delta) {
         this.mannerTemp = Math.max(0, Math.min(100, this.mannerTemp + delta));
+    }
+
+    public boolean isSuspended() {
+        return suspendedUntil != null && suspendedUntil.isAfter(java.time.LocalDateTime.now());
+    }
+
+    public void recordNoShow(int suspendDays) {
+        this.noShowCount++;
+        updateMannerTemp(-5.0);
+        if (this.noShowCount >= 2) {
+            this.suspendedUntil = java.time.LocalDateTime.now().plusDays(suspendDays);
+        }
     }
 
     public boolean isAdmin() {

--- a/backend/src/main/java/com/yonta/domain/UserNotification.java
+++ b/backend/src/main/java/com/yonta/domain/UserNotification.java
@@ -1,0 +1,52 @@
+package com.yonta.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_notification", indexes = {
+        @Index(name = "idx_notification_user_read", columnList = "user_id, read_flag, created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "taxi_party_id")
+    private TaxiParty taxiParty;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, length = 300)
+    private String body;
+
+    @Column(name = "read_flag", nullable = false)
+    private boolean read;
+
+    @Builder
+    public UserNotification(User user, TaxiParty taxiParty, NotificationType type, String title, String body) {
+        this.user = user;
+        this.taxiParty = taxiParty;
+        this.type = type;
+        this.title = title;
+        this.body = body;
+        this.read = false;
+    }
+
+    public void markRead() {
+        this.read = true;
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/request/ChatMessageRequest.java
+++ b/backend/src/main/java/com/yonta/dto/request/ChatMessageRequest.java
@@ -1,0 +1,15 @@
+package com.yonta.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageRequest {
+
+    @NotBlank(message = "메시지를 입력해주세요.")
+    @Size(max = 500, message = "메시지는 500자 이하여야 합니다.")
+    private String content;
+}

--- a/backend/src/main/java/com/yonta/dto/request/MemberReviewRequest.java
+++ b/backend/src/main/java/com/yonta/dto/request/MemberReviewRequest.java
@@ -1,0 +1,24 @@
+package com.yonta.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberReviewRequest {
+
+    @NotNull(message = "평가 대상이 필요합니다.")
+    private Long revieweeId;
+
+    @NotNull(message = "평점은 필수입니다.")
+    @Min(value = 1, message = "평점은 1~5점이어야 합니다.")
+    @Max(value = 5, message = "평점은 1~5점이어야 합니다.")
+    private Integer rating;
+
+    @Size(max = 300, message = "평가 메모는 300자 이하로 입력해주세요.")
+    private String comment;
+}

--- a/backend/src/main/java/com/yonta/dto/request/NoShowReportRequest.java
+++ b/backend/src/main/java/com/yonta/dto/request/NoShowReportRequest.java
@@ -1,0 +1,19 @@
+package com.yonta.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NoShowReportRequest {
+
+    @NotNull(message = "신고 대상이 필요합니다.")
+    private Long reportedUserId;
+
+    @NotBlank(message = "신고 사유를 입력해주세요.")
+    @Size(max = 500, message = "신고 사유는 500자 이하로 입력해주세요.")
+    private String reason;
+}

--- a/backend/src/main/java/com/yonta/dto/response/ChatMessageResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/ChatMessageResponse.java
@@ -1,0 +1,30 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.PartyMessage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ChatMessageResponse {
+
+    private final Long id;
+    private final Long partyId;
+    private final Long senderId;
+    private final String senderAlias;
+    private final String content;
+    private final LocalDateTime sentAt;
+
+    public static ChatMessageResponse from(PartyMessage message, String senderAlias) {
+        return ChatMessageResponse.builder()
+                .id(message.getId())
+                .partyId(message.getTaxiParty().getId())
+                .senderId(message.getSender().getId())
+                .senderAlias(senderAlias)
+                .content(message.getContent())
+                .sentAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/HistoryMemberResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/HistoryMemberResponse.java
@@ -1,0 +1,14 @@
+package com.yonta.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HistoryMemberResponse {
+
+    private final Long userId;
+    private final String alias;
+    private final boolean reviewedByMe;
+    private final boolean noShowReportedByMe;
+}

--- a/backend/src/main/java/com/yonta/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/LoginResponse.java
@@ -13,6 +13,9 @@ public class LoginResponse {
     private String email;
     private String studentId;
     private double mannerTemp;
+    private boolean suspended;
+    private java.time.LocalDateTime suspendedUntil;
+    private int noShowCount;
 
     public static LoginResponse of(String token, User user) {
         return LoginResponse.builder()
@@ -22,6 +25,9 @@ public class LoginResponse {
                 .email(user.getEmail())
                 .studentId(user.getStudentId())
                 .mannerTemp(user.getMannerTemp())
+                .suspended(user.isSuspended())
+                .suspendedUntil(user.getSuspendedUntil())
+                .noShowCount(user.getNoShowCount())
                 .build();
     }
 }

--- a/backend/src/main/java/com/yonta/dto/response/MemberReviewResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/MemberReviewResponse.java
@@ -1,0 +1,32 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.MemberReview;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MemberReviewResponse {
+
+    private final Long id;
+    private final Long partyId;
+    private final Long revieweeId;
+    private final String reviewerAlias;
+    private final int rating;
+    private final String comment;
+    private final LocalDateTime createdAt;
+
+    public static MemberReviewResponse from(MemberReview review, String reviewerAlias) {
+        return MemberReviewResponse.builder()
+                .id(review.getId())
+                .partyId(review.getTaxiParty().getId())
+                .revieweeId(review.getReviewee().getId())
+                .reviewerAlias(reviewerAlias)
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/NoShowReportResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/NoShowReportResponse.java
@@ -1,0 +1,36 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.NoShowReport;
+import com.yonta.domain.NoShowReportStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NoShowReportResponse {
+
+    private final Long id;
+    private final Long partyId;
+    private final Long reportedUserId;
+    private final NoShowReportStatus status;
+    private final String statusLabel;
+    private final String message;
+    private final LocalDateTime createdAt;
+
+    public static NoShowReportResponse from(NoShowReport report) {
+        String message = report.getStatus() == NoShowReportStatus.CONFIRMED
+                ? "노쇼가 확정되었습니다. 해당 사용자의 매너 온도가 하락했습니다."
+                : "신고가 접수되었습니다. 다른 파티원 1명의 추가 신고 시 확정됩니다.";
+        return NoShowReportResponse.builder()
+                .id(report.getId())
+                .partyId(report.getTaxiParty().getId())
+                .reportedUserId(report.getReportedUser().getId())
+                .status(report.getStatus())
+                .statusLabel(report.getStatus().getLabel())
+                .message(message)
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/NotificationResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/NotificationResponse.java
@@ -1,0 +1,33 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.NotificationType;
+import com.yonta.domain.UserNotification;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class NotificationResponse {
+
+    private final Long id;
+    private final NotificationType type;
+    private final String title;
+    private final String body;
+    private final Long partyId;
+    private final boolean read;
+    private final LocalDateTime createdAt;
+
+    public static NotificationResponse from(UserNotification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .type(notification.getType())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .partyId(notification.getTaxiParty() != null ? notification.getTaxiParty().getId() : null)
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/PartyHistoryResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/PartyHistoryResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -16,6 +17,8 @@ public class PartyHistoryResponse {
     private Integer myRating;
     private String myComment;
     private LocalDateTime reviewedAt;
+    private List<HistoryMemberResponse> otherMembers;
+    private List<ReceivedReviewResponse> receivedReviews;
 
     public static PartyHistoryResponse from(TaxiParty party, PartyReview review, boolean mine) {
         return PartyHistoryResponse.builder()
@@ -24,6 +27,8 @@ public class PartyHistoryResponse {
                 .myRating(review != null ? review.getRating() : null)
                 .myComment(review != null ? review.getComment() : null)
                 .reviewedAt(review != null ? review.getCreatedAt() : null)
+                .otherMembers(List.of())
+                .receivedReviews(List.of())
                 .build();
     }
 }

--- a/backend/src/main/java/com/yonta/dto/response/PartyUpdateEvent.java
+++ b/backend/src/main/java/com/yonta/dto/response/PartyUpdateEvent.java
@@ -1,0 +1,46 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.PartyStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PartyUpdateEvent {
+
+    private final Long partyId;
+    private final PartyStatus status;
+    private final int currentCount;
+    private final int maxCount;
+    private final String eventType;
+
+    public static PartyUpdateEvent joined(Long partyId, PartyStatus status, int currentCount, int maxCount) {
+        return PartyUpdateEvent.builder()
+                .partyId(partyId)
+                .status(status)
+                .currentCount(currentCount)
+                .maxCount(maxCount)
+                .eventType("JOINED")
+                .build();
+    }
+
+    public static PartyUpdateEvent left(Long partyId, PartyStatus status, int currentCount, int maxCount) {
+        return PartyUpdateEvent.builder()
+                .partyId(partyId)
+                .status(status)
+                .currentCount(currentCount)
+                .maxCount(maxCount)
+                .eventType("LEFT")
+                .build();
+    }
+
+    public static PartyUpdateEvent statusChanged(Long partyId, PartyStatus status, int currentCount, int maxCount) {
+        return PartyUpdateEvent.builder()
+                .partyId(partyId)
+                .status(status)
+                .currentCount(currentCount)
+                .maxCount(maxCount)
+                .eventType("STATUS_CHANGED")
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/ReceivedReviewResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/ReceivedReviewResponse.java
@@ -1,0 +1,30 @@
+package com.yonta.dto.response;
+
+import com.yonta.domain.MemberReview;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReceivedReviewResponse {
+
+    private final Long id;
+    private final Long partyId;
+    private final String reviewerAlias;
+    private final int rating;
+    private final String comment;
+    private final LocalDateTime createdAt;
+
+    public static ReceivedReviewResponse from(MemberReview review, String reviewerAlias) {
+        return ReceivedReviewResponse.builder()
+                .id(review.getId())
+                .partyId(review.getTaxiParty().getId())
+                .reviewerAlias(reviewerAlias)
+                .rating(review.getRating())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/yonta/dto/response/TrustDashboardResponse.java
+++ b/backend/src/main/java/com/yonta/dto/response/TrustDashboardResponse.java
@@ -1,0 +1,24 @@
+package com.yonta.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class TrustDashboardResponse {
+
+    private final double mannerTemp;
+    private final String trustLevel;
+    private final String trustLevelLabel;
+    private final Double averageRatingReceived;
+    private final long totalReviewsReceived;
+    private final long totalPartiesJoined;
+    private final int noShowCount;
+    private final boolean suspended;
+    private final LocalDateTime suspendedUntil;
+    private final List<ReceivedReviewResponse> recentReviewsReceived;
+    private final List<PartyHistoryResponse> partyHistory;
+}

--- a/backend/src/main/java/com/yonta/exception/ErrorCode.java
+++ b/backend/src/main/java/com/yonta/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "U002", "비밀번호가 일치하지 않습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "U003", "이용 정지 상태입니다. 정지 해제 후 다시 이용해주세요."),
 
     // TaxiParty
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "합승 파티를 찾을 수 없습니다."),
@@ -39,6 +40,14 @@ public enum ErrorCode {
     INVALID_PARTY_OPTION(HttpStatus.BAD_REQUEST, "P010", "파티 옵션 값이 올바르지 않습니다."),
     PARTY_REVIEW_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "P011", "지난 파티에 대해서만 평가를 남길 수 있습니다."),
     PARTY_ALREADY_REVIEWED(HttpStatus.CONFLICT, "P012", "이미 해당 파티에 대한 평가를 남겼습니다."),
+    CHAT_NOT_MEMBER(HttpStatus.FORBIDDEN, "P016", "파티 멤버만 채팅에 참여할 수 있습니다."),
+    MEMBER_ALREADY_REVIEWED(HttpStatus.CONFLICT, "P017", "이미 해당 멤버를 평가했습니다."),
+    REVIEW_TARGET_NOT_IN_PARTY(HttpStatus.BAD_REQUEST, "P018", "같은 파티에 참여한 멤버만 평가/신고할 수 있습니다."),
+    CANNOT_REPORT_SELF(HttpStatus.BAD_REQUEST, "P019", "본인은 신고할 수 없습니다."),
+    NO_SHOW_ALREADY_REPORTED(HttpStatus.CONFLICT, "P020", "이미 해당 사용자를 노쇼 신고했습니다."),
+
+    // Notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "N001", "알림을 찾을 수 없습니다."),
 
     // Admin
     ADMIN_ACCESS_DENIED(HttpStatus.FORBIDDEN, "X001", "관리자 권한이 필요합니다.");

--- a/backend/src/main/java/com/yonta/repository/MemberReviewRepository.java
+++ b/backend/src/main/java/com/yonta/repository/MemberReviewRepository.java
@@ -1,0 +1,25 @@
+package com.yonta.repository;
+
+import com.yonta.domain.MemberReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberReviewRepository extends JpaRepository<MemberReview, Long> {
+
+    boolean existsByTaxiPartyIdAndReviewerIdAndRevieweeId(Long taxiPartyId, Long reviewerId, Long revieweeId);
+
+    List<MemberReview> findByRevieweeIdOrderByCreatedAtDesc(Long revieweeId);
+
+    List<MemberReview> findByReviewerIdAndTaxiPartyId(Long reviewerId, Long taxiPartyId);
+
+    List<MemberReview> findByTaxiPartyIdAndRevieweeId(Long taxiPartyId, Long revieweeId);
+
+    @Query("SELECT AVG(r.rating) FROM MemberReview r WHERE r.reviewee.id = :userId")
+    Optional<Double> findAverageRatingByRevieweeId(@Param("userId") Long userId);
+
+    long countByRevieweeId(Long revieweeId);
+}

--- a/backend/src/main/java/com/yonta/repository/NoShowReportRepository.java
+++ b/backend/src/main/java/com/yonta/repository/NoShowReportRepository.java
@@ -1,0 +1,22 @@
+package com.yonta.repository;
+
+import com.yonta.domain.NoShowReport;
+import com.yonta.domain.NoShowReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NoShowReportRepository extends JpaRepository<NoShowReport, Long> {
+
+    boolean existsByTaxiPartyIdAndReporterIdAndReportedUserId(Long taxiPartyId, Long reporterId, Long reportedUserId);
+
+    long countByTaxiPartyIdAndReportedUserIdAndStatus(Long taxiPartyId, Long reportedUserId, NoShowReportStatus status);
+
+    List<NoShowReport> findByTaxiPartyIdAndReportedUserId(Long taxiPartyId, Long reportedUserId);
+
+    List<NoShowReport> findByReportedUserIdOrderByCreatedAtDesc(Long reportedUserId);
+
+    Optional<NoShowReport> findByTaxiPartyIdAndReporterIdAndReportedUserId(
+            Long taxiPartyId, Long reporterId, Long reportedUserId);
+}

--- a/backend/src/main/java/com/yonta/repository/PartyMessageRepository.java
+++ b/backend/src/main/java/com/yonta/repository/PartyMessageRepository.java
@@ -1,0 +1,11 @@
+package com.yonta.repository;
+
+import com.yonta.domain.PartyMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PartyMessageRepository extends JpaRepository<PartyMessage, Long> {
+
+    List<PartyMessage> findTop50ByTaxiPartyIdOrderByCreatedAtAsc(Long taxiPartyId);
+}

--- a/backend/src/main/java/com/yonta/repository/TaxiPartyRepository.java
+++ b/backend/src/main/java/com/yonta/repository/TaxiPartyRepository.java
@@ -37,4 +37,27 @@ public interface TaxiPartyRepository extends JpaRepository<TaxiParty, Long> {
             @Param("now") LocalDateTime now);
 
     List<TaxiParty> findByHostIdOrderByCreatedAtDesc(Long hostId);
+
+    @Query("SELECT tp FROM TaxiParty tp " +
+           "WHERE tp.status IN :statuses " +
+           "AND tp.departureTime <= :now")
+    List<TaxiParty> findByStatusInAndDepartureTimeBefore(
+            @Param("statuses") List<PartyStatus> statuses,
+            @Param("now") LocalDateTime now);
+
+    @Query("SELECT tp FROM TaxiParty tp " +
+           "WHERE tp.status = :status " +
+           "AND tp.departureTime <= :cutoff")
+    List<TaxiParty> findByStatusAndDepartureTimeBefore(
+            @Param("status") PartyStatus status,
+            @Param("cutoff") LocalDateTime cutoff);
+
+    @Query("SELECT tp FROM TaxiParty tp " +
+           "WHERE tp.status IN :statuses " +
+           "AND tp.departureTime > :from " +
+           "AND tp.departureTime <= :to")
+    List<TaxiParty> findPartiesDepartingBetween(
+            @Param("statuses") List<PartyStatus> statuses,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to);
 }

--- a/backend/src/main/java/com/yonta/repository/UserNotificationRepository.java
+++ b/backend/src/main/java/com/yonta/repository/UserNotificationRepository.java
@@ -1,0 +1,16 @@
+package com.yonta.repository;
+
+import com.yonta.domain.NotificationType;
+import com.yonta.domain.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+
+    List<UserNotification> findTop30ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    long countByUserIdAndReadFalse(Long userId);
+
+    boolean existsByTaxiPartyIdAndType(Long taxiPartyId, NotificationType type);
+}

--- a/backend/src/main/java/com/yonta/security/StompAuthChannelInterceptor.java
+++ b/backend/src/main/java/com/yonta/security/StompAuthChannelInterceptor.java
@@ -1,0 +1,56 @@
+package com.yonta.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null || accessor.getCommand() != StompCommand.CONNECT) {
+            return message;
+        }
+
+        String token = resolveToken(accessor);
+        if (token == null || !jwtTokenProvider.validate(token)) {
+            throw new IllegalArgumentException("WebSocket 인증에 실패했습니다.");
+        }
+
+        Long userId = jwtTokenProvider.getUserId(token);
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(userId, null, List.of());
+        accessor.setUser(auth);
+
+        return message;
+    }
+
+    private String resolveToken(StompHeaderAccessor accessor) {
+        List<String> authHeaders = accessor.getNativeHeader("Authorization");
+        if (authHeaders != null && !authHeaders.isEmpty()) {
+            String header = authHeaders.get(0);
+            if (header.startsWith("Bearer ")) {
+                return header.substring(7);
+            }
+            return header;
+        }
+        List<String> tokens = accessor.getNativeHeader("token");
+        if (tokens != null && !tokens.isEmpty()) {
+            return tokens.get(0);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/yonta/service/AuthService.java
+++ b/backend/src/main/java/com/yonta/service/AuthService.java
@@ -29,6 +29,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TrustService trustService;
 
     public void sendVerificationCode(String email) {
         validateYonseiEmail(email);
@@ -104,6 +105,9 @@ public class AuthService {
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+        if (user.isSuspended()) {
+            throw new CustomException(ErrorCode.USER_SUSPENDED);
         }
 
         String token = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getRole().name());

--- a/backend/src/main/java/com/yonta/service/NotificationService.java
+++ b/backend/src/main/java/com/yonta/service/NotificationService.java
@@ -1,0 +1,82 @@
+package com.yonta.service;
+
+import com.yonta.domain.*;
+import com.yonta.dto.response.NotificationResponse;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.repository.ParticipantRepository;
+import com.yonta.repository.UserNotificationRepository;
+import com.yonta.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final UserNotificationRepository notificationRepository;
+    private final ParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+    private final RealtimeEventPublisher eventPublisher;
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getMyNotifications(Long userId) {
+        return notificationRepository.findTop30ByUserIdOrderByCreatedAtDesc(userId).stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public long getUnreadCount(Long userId) {
+        return notificationRepository.countByUserIdAndReadFalse(userId);
+    }
+
+    @Transactional
+    public void markAsRead(Long userId, Long notificationId) {
+        UserNotification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+        notification.markRead();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        notificationRepository.findTop30ByUserIdOrderByCreatedAtDesc(userId).stream()
+                .filter(n -> !n.isRead())
+                .forEach(UserNotification::markRead);
+    }
+
+    @Transactional
+    public void notifyUser(User user, TaxiParty party, NotificationType type, String title, String body) {
+        UserNotification saved = notificationRepository.save(
+                UserNotification.builder()
+                        .user(user)
+                        .taxiParty(party)
+                        .type(type)
+                        .title(title)
+                        .body(body)
+                        .build()
+        );
+        eventPublisher.publishNotification(user.getId(), NotificationResponse.from(saved));
+    }
+
+    @Transactional
+    public void notifyPartyMembers(TaxiParty party, Long excludeUserId, NotificationType type, String title, String body) {
+        participantRepository.findByTaxiPartyId(party.getId()).forEach(participant -> {
+            User member = participant.getUser();
+            if (excludeUserId != null && member.getId().equals(excludeUserId)) {
+                return;
+            }
+            notifyUser(member, party, type, title, body);
+        });
+    }
+
+    public boolean hasDepartureReminder(Long partyId) {
+        return notificationRepository.existsByTaxiPartyIdAndType(partyId, NotificationType.DEPARTURE_SOON);
+    }
+}

--- a/backend/src/main/java/com/yonta/service/PartyChatService.java
+++ b/backend/src/main/java/com/yonta/service/PartyChatService.java
@@ -1,0 +1,82 @@
+package com.yonta.service;
+
+import com.yonta.domain.PartyMessage;
+import com.yonta.domain.Participant;
+import com.yonta.domain.TaxiParty;
+import com.yonta.domain.User;
+import com.yonta.dto.response.ChatMessageResponse;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.repository.ParticipantRepository;
+import com.yonta.repository.PartyMessageRepository;
+import com.yonta.repository.TaxiPartyRepository;
+import com.yonta.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Service
+@RequiredArgsConstructor
+public class PartyChatService {
+
+    private final PartyMessageRepository messageRepository;
+    private final TaxiPartyRepository taxiPartyRepository;
+    private final ParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+    private final RealtimeEventPublisher eventPublisher;
+
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponse> getMessages(Long partyId, Long userId) {
+        verifyMember(partyId, userId);
+        List<PartyMessage> messages = messageRepository.findTop50ByTaxiPartyIdOrderByCreatedAtAsc(partyId);
+        List<Participant> participants = participantRepository.findByTaxiPartyId(partyId);
+        return messages.stream()
+                .map(m -> ChatMessageResponse.from(m, resolveAlias(m.getSender().getId(), participants)))
+                .toList();
+    }
+
+    @Transactional
+    public ChatMessageResponse sendMessage(Long partyId, Long userId, String content) {
+        verifyMember(partyId, userId);
+        TaxiParty party = taxiPartyRepository.findById(partyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PARTY_NOT_FOUND));
+        User sender = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        PartyMessage saved = messageRepository.save(
+                PartyMessage.builder()
+                        .taxiParty(party)
+                        .sender(sender)
+                        .content(content)
+                        .build()
+        );
+
+        List<Participant> participants = participantRepository.findByTaxiPartyId(partyId);
+        ChatMessageResponse response = ChatMessageResponse.from(
+                saved,
+                resolveAlias(sender.getId(), participants)
+        );
+        eventPublisher.publishChatMessage(partyId, response);
+        return response;
+    }
+
+    private void verifyMember(Long partyId, Long userId) {
+        if (!participantRepository.existsByTaxiPartyIdAndUserId(partyId, userId)) {
+            throw new CustomException(ErrorCode.CHAT_NOT_MEMBER);
+        }
+    }
+
+    private String resolveAlias(Long userId, List<Participant> participants) {
+        AtomicInteger index = new AtomicInteger(1);
+        for (Participant p : participants) {
+            if (p.getUser().getId().equals(userId)) {
+                return p.isHost() ? "방장" : "탑승자 " + index.get();
+            }
+            index.incrementAndGet();
+        }
+        return "탑승자";
+    }
+}

--- a/backend/src/main/java/com/yonta/service/PartyService.java
+++ b/backend/src/main/java/com/yonta/service/PartyService.java
@@ -5,6 +5,7 @@ import com.yonta.dto.request.PartyCreateRequest;
 import com.yonta.dto.request.PartyReviewRequest;
 import com.yonta.dto.response.PartyHistoryResponse;
 import com.yonta.dto.response.PartyResponse;
+import com.yonta.dto.response.PartyUpdateEvent;
 import com.yonta.exception.CustomException;
 import com.yonta.exception.ErrorCode;
 import com.yonta.repository.ParticipantRepository;
@@ -30,6 +31,9 @@ public class PartyService {
     private final ParticipantRepository participantRepository;
     private final PartyReviewRepository partyReviewRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
+    private final RealtimeEventPublisher eventPublisher;
+    private final TrustService trustService;
 
     @Transactional(readOnly = true)
     public List<PartyResponse> getAvailableParties(Location departure, Location destination, Long userId) {
@@ -50,6 +54,7 @@ public class PartyService {
 
     @Transactional
     public PartyResponse createParty(PartyCreateRequest request, Long userId) {
+        trustService.ensureUserCanParticipate(userId);
         User host = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
@@ -76,6 +81,7 @@ public class PartyService {
 
     @Transactional
     public PartyResponse joinParty(Long partyId, Long userId) {
+        trustService.ensureUserCanParticipate(userId);
         TaxiParty party = getParty(partyId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -93,6 +99,17 @@ public class PartyService {
             throw new CustomException(ErrorCode.PARTY_FULL);
         }
         participantRepository.save(Participant.createGuest(party, user));
+        publishPartyUpdate(party, "JOINED");
+        notificationService.notifyPartyMembers(
+                party,
+                userId,
+                NotificationType.MEMBER_JOINED,
+                "새 멤버가 참여했습니다",
+                String.format("현재 %d/%d명 · %s → %s",
+                        party.getCurrentCount(), party.getMaxCount(),
+                        party.getDeparture().getDisplayName(),
+                        party.getDestination().getDisplayName())
+        );
         return PartyResponse.from(party, true);
     }
 
@@ -109,6 +126,15 @@ public class PartyService {
 
         participantRepository.delete(participant);
         party.decrementCount();
+        publishPartyUpdate(party, "LEFT");
+        notificationService.notifyPartyMembers(
+                party,
+                userId,
+                NotificationType.MEMBER_LEFT,
+                "멤버가 파티를 나갔습니다",
+                String.format("현재 %d/%d명",
+                        party.getCurrentCount(), party.getMaxCount())
+        );
         return PartyResponse.from(party, false);
     }
 
@@ -163,23 +189,7 @@ public class PartyService {
 
     @Transactional(readOnly = true)
     public List<PartyHistoryResponse> getMyPartyHistory(Long userId) {
-        LocalDateTime now = LocalDateTime.now();
-        List<TaxiParty> pastParties = participantRepository.findByUserId(userId).stream()
-                .map(Participant::getTaxiParty)
-                .filter(p -> !p.getDepartureTime().isAfter(now))
-                .sorted(Comparator.comparing(TaxiParty::getDepartureTime).reversed())
-                .toList();
-
-        List<Long> partyIds = pastParties.stream().map(TaxiParty::getId).toList();
-        if (partyIds.isEmpty()) {
-            return List.of();
-        }
-        List<PartyReview> reviews = partyReviewRepository.findByReviewerIdAndTaxiPartyIdIn(userId, partyIds);
-        var reviewMap = reviews.stream().collect(Collectors.toMap(r -> r.getTaxiParty().getId(), r -> r));
-
-        return pastParties.stream()
-                .map(p -> PartyHistoryResponse.from(p, reviewMap.get(p.getId()), true))
-                .toList();
+        return trustService.buildPartyHistory(userId);
     }
 
     @Transactional
@@ -205,7 +215,11 @@ public class PartyService {
                 .comment(request.getComment())
                 .build();
         PartyReview saved = partyReviewRepository.save(review);
-        return PartyHistoryResponse.from(party, saved, true);
+        party.getHost().updateMannerTemp((request.getRating() - 3) * 0.5);
+        return trustService.buildPartyHistory(userId).stream()
+                .filter(h -> h.getParty().getId().equals(partyId))
+                .findFirst()
+                .orElse(PartyHistoryResponse.from(party, saved, true));
     }
 
     private TaxiParty getParty(Long partyId) {
@@ -269,5 +283,17 @@ public class PartyService {
         } catch (DateTimeParseException e) {
             throw new CustomException(ErrorCode.INVALID_TIME_SLOT);
         }
+    }
+
+    private void publishPartyUpdate(TaxiParty party, String eventType) {
+        PartyUpdateEvent event = switch (eventType) {
+            case "JOINED" -> PartyUpdateEvent.joined(
+                    party.getId(), party.getStatus(), party.getCurrentCount(), party.getMaxCount());
+            case "LEFT" -> PartyUpdateEvent.left(
+                    party.getId(), party.getStatus(), party.getCurrentCount(), party.getMaxCount());
+            default -> PartyUpdateEvent.statusChanged(
+                    party.getId(), party.getStatus(), party.getCurrentCount(), party.getMaxCount());
+        };
+        eventPublisher.publishPartyUpdate(party.getId(), event);
     }
 }

--- a/backend/src/main/java/com/yonta/service/PartyStatusScheduler.java
+++ b/backend/src/main/java/com/yonta/service/PartyStatusScheduler.java
@@ -1,0 +1,108 @@
+package com.yonta.service;
+
+import com.yonta.domain.PartyStatus;
+import com.yonta.domain.TaxiParty;
+import com.yonta.dto.response.PartyUpdateEvent;
+import com.yonta.repository.TaxiPartyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PartyStatusScheduler {
+
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final TaxiPartyRepository taxiPartyRepository;
+    private final NotificationService notificationService;
+    private final RealtimeEventPublisher eventPublisher;
+
+    @Scheduled(cron = "0 */1 * * * *")
+    @Transactional
+    public void processPartyLifecycle() {
+        LocalDateTime now = LocalDateTime.now();
+        autoDepartParties(now);
+        autoSettleParties(now);
+        sendDepartureReminders(now);
+    }
+
+    private void autoDepartParties(LocalDateTime now) {
+        List<TaxiParty> parties = taxiPartyRepository.findByStatusInAndDepartureTimeBefore(
+                List.of(PartyStatus.RECRUITING, PartyStatus.FULL),
+                now
+        );
+        for (TaxiParty party : parties) {
+            party.depart();
+            log.info("파티 {} 자동 출발 처리 (DEPARTED)", party.getId());
+            eventPublisher.publishPartyUpdate(
+                    party.getId(),
+                    PartyUpdateEvent.statusChanged(
+                            party.getId(), party.getStatus(),
+                            party.getCurrentCount(), party.getMaxCount()
+                    )
+            );
+            notificationService.notifyPartyMembers(
+                    party,
+                    null,
+                    com.yonta.domain.NotificationType.PARTY_DEPARTED,
+                    "출발 시간이 되었습니다",
+                    String.format("%s → %s 파티가 출발 처리되었습니다.",
+                            party.getDeparture().getDisplayName(),
+                            party.getDestination().getDisplayName())
+            );
+        }
+    }
+
+    private void autoSettleParties(LocalDateTime now) {
+        LocalDateTime cutoff = now.minusHours(2);
+        List<TaxiParty> parties = taxiPartyRepository.findByStatusAndDepartureTimeBefore(
+                PartyStatus.DEPARTED,
+                cutoff
+        );
+        for (TaxiParty party : parties) {
+            party.settle();
+            log.info("파티 {} 자동 종료 처리 (SETTLED)", party.getId());
+            eventPublisher.publishPartyUpdate(
+                    party.getId(),
+                    PartyUpdateEvent.statusChanged(
+                            party.getId(), party.getStatus(),
+                            party.getCurrentCount(), party.getMaxCount()
+                    )
+            );
+        }
+    }
+
+    private void sendDepartureReminders(LocalDateTime now) {
+        LocalDateTime from = now.plusMinutes(9);
+        LocalDateTime to = now.plusMinutes(11);
+        List<TaxiParty> parties = taxiPartyRepository.findPartiesDepartingBetween(
+                List.of(PartyStatus.RECRUITING, PartyStatus.FULL),
+                from,
+                to
+        );
+        for (TaxiParty party : parties) {
+            if (notificationService.hasDepartureReminder(party.getId())) {
+                continue;
+            }
+            String timeLabel = party.getDepartureTime().format(TIME_FMT);
+            notificationService.notifyPartyMembers(
+                    party,
+                    null,
+                    com.yonta.domain.NotificationType.DEPARTURE_SOON,
+                    "출발 10분 전입니다",
+                    String.format("%s 출발 예정 파티입니다. (%s → %s)",
+                            timeLabel,
+                            party.getDeparture().getDisplayName(),
+                            party.getDestination().getDisplayName())
+            );
+        }
+    }
+}

--- a/backend/src/main/java/com/yonta/service/RealtimeEventPublisher.java
+++ b/backend/src/main/java/com/yonta/service/RealtimeEventPublisher.java
@@ -1,0 +1,31 @@
+package com.yonta.service;
+
+import com.yonta.dto.response.ChatMessageResponse;
+import com.yonta.dto.response.NotificationResponse;
+import com.yonta.dto.response.PartyUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RealtimeEventPublisher {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void publishChatMessage(Long partyId, ChatMessageResponse message) {
+        messagingTemplate.convertAndSend("/topic/party." + partyId + ".chat", message);
+    }
+
+    public void publishPartyUpdate(Long partyId, PartyUpdateEvent event) {
+        messagingTemplate.convertAndSend("/topic/party." + partyId + ".update", event);
+    }
+
+    public void publishNotification(Long userId, NotificationResponse notification) {
+        messagingTemplate.convertAndSendToUser(
+                String.valueOf(userId),
+                "/queue/notifications",
+                notification
+        );
+    }
+}

--- a/backend/src/main/java/com/yonta/service/TrustService.java
+++ b/backend/src/main/java/com/yonta/service/TrustService.java
@@ -1,0 +1,268 @@
+package com.yonta.service;
+
+import com.yonta.domain.*;
+import com.yonta.dto.request.MemberReviewRequest;
+import com.yonta.dto.request.NoShowReportRequest;
+import com.yonta.dto.response.*;
+import com.yonta.exception.CustomException;
+import com.yonta.exception.ErrorCode;
+import com.yonta.repository.*;
+import com.yonta.util.TrustLevelUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TrustService {
+
+    private static final int NO_SHOW_SUSPEND_DAYS = 7;
+    private static final int NO_SHOW_CONFIRM_THRESHOLD = 2;
+
+    private final UserRepository userRepository;
+    private final TaxiPartyRepository taxiPartyRepository;
+    private final ParticipantRepository participantRepository;
+    private final PartyReviewRepository partyReviewRepository;
+    private final MemberReviewRepository memberReviewRepository;
+    private final NoShowReportRepository noShowReportRepository;
+
+    public void ensureUserCanParticipate(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        if (user.isSuspended()) {
+            throw new CustomException(ErrorCode.USER_SUSPENDED);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public TrustDashboardResponse getDashboard(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Double avgRating = memberReviewRepository.findAverageRatingByRevieweeId(userId).orElse(null);
+        long reviewCount = memberReviewRepository.countByRevieweeId(userId);
+        TrustLevelUtil.TrustLevel level = TrustLevelUtil.resolve(user.getMannerTemp(), avgRating);
+
+        List<ReceivedReviewResponse> recentReviews = memberReviewRepository
+                .findByRevieweeIdOrderByCreatedAtDesc(userId).stream()
+                .limit(10)
+                .map(r -> ReceivedReviewResponse.from(r, "익명 탑승자"))
+                .toList();
+
+        List<PartyHistoryResponse> history = buildPartyHistory(userId);
+
+        long joinedCount = participantRepository.findByUserId(userId).size();
+
+        return TrustDashboardResponse.builder()
+                .mannerTemp(user.getMannerTemp())
+                .trustLevel(level.name())
+                .trustLevelLabel(level.getLabel())
+                .averageRatingReceived(avgRating)
+                .totalReviewsReceived(reviewCount)
+                .totalPartiesJoined(joinedCount)
+                .noShowCount(user.getNoShowCount())
+                .suspended(user.isSuspended())
+                .suspendedUntil(user.getSuspendedUntil())
+                .recentReviewsReceived(recentReviews)
+                .partyHistory(history)
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PartyHistoryResponse> buildPartyHistory(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+        List<TaxiParty> pastParties = participantRepository.findByUserId(userId).stream()
+                .map(Participant::getTaxiParty)
+                .filter(p -> !p.getDepartureTime().isAfter(now))
+                .sorted(Comparator.comparing(TaxiParty::getDepartureTime).reversed())
+                .toList();
+
+        if (pastParties.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> partyIds = pastParties.stream().map(TaxiParty::getId).toList();
+        List<PartyReview> myPartyReviews = partyReviewRepository.findByReviewerIdAndTaxiPartyIdIn(userId, partyIds);
+        var partyReviewMap = myPartyReviews.stream()
+                .collect(Collectors.toMap(r -> r.getTaxiParty().getId(), r -> r));
+
+        return pastParties.stream()
+                .map(party -> enrichHistory(party, userId, partyReviewMap.get(party.getId())))
+                .toList();
+    }
+
+    private PartyHistoryResponse enrichHistory(TaxiParty party, Long userId, PartyReview partyReview) {
+        List<Participant> participants = participantRepository.findByTaxiPartyId(party.getId());
+        Map<Long, String> aliasMap = buildAliasMap(participants);
+
+        List<MemberReview> myMemberReviews = memberReviewRepository.findByReviewerIdAndTaxiPartyId(userId, party.getId());
+        Set<Long> reviewedIds = myMemberReviews.stream()
+                .map(r -> r.getReviewee().getId())
+                .collect(Collectors.toSet());
+
+        Set<Long> reportedByMe = participants.stream()
+                .filter(p -> !p.getUser().getId().equals(userId))
+                .filter(p -> noShowReportRepository.existsByTaxiPartyIdAndReporterIdAndReportedUserId(
+                        party.getId(), userId, p.getUser().getId()))
+                .map(p -> p.getUser().getId())
+                .collect(Collectors.toSet());
+
+        List<HistoryMemberResponse> others = participants.stream()
+                .filter(p -> !p.getUser().getId().equals(userId))
+                .map(p -> HistoryMemberResponse.builder()
+                        .userId(p.getUser().getId())
+                        .alias(aliasMap.getOrDefault(p.getUser().getId(), "탑승자"))
+                        .reviewedByMe(reviewedIds.contains(p.getUser().getId()))
+                        .noShowReportedByMe(reportedByMe.contains(p.getUser().getId()))
+                        .build())
+                .toList();
+
+        List<ReceivedReviewResponse> received = memberReviewRepository
+                .findByTaxiPartyIdAndRevieweeId(party.getId(), userId).stream()
+                .map(r -> ReceivedReviewResponse.from(r, aliasMap.getOrDefault(r.getReviewer().getId(), "익명")))
+                .toList();
+
+        return PartyHistoryResponse.builder()
+                .party(PartyResponse.from(party, participants, true, userId))
+                .reviewed(partyReview != null)
+                .myRating(partyReview != null ? partyReview.getRating() : null)
+                .myComment(partyReview != null ? partyReview.getComment() : null)
+                .reviewedAt(partyReview != null ? partyReview.getCreatedAt() : null)
+                .otherMembers(others)
+                .receivedReviews(received)
+                .build();
+    }
+
+    @Transactional
+    public MemberReviewResponse submitMemberReview(Long partyId, Long userId, MemberReviewRequest request) {
+        ensurePastPartyMember(partyId, userId);
+        ensureUserCanParticipate(userId);
+
+        if (memberReviewRepository.existsByTaxiPartyIdAndReviewerIdAndRevieweeId(
+                partyId, userId, request.getRevieweeId())) {
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_REVIEWED);
+        }
+
+        TaxiParty party = getParty(partyId);
+        User reviewer = getUser(userId);
+        User reviewee = getUser(request.getRevieweeId());
+
+        if (!participantRepository.existsByTaxiPartyIdAndUserId(partyId, request.getRevieweeId())) {
+            throw new CustomException(ErrorCode.REVIEW_TARGET_NOT_IN_PARTY);
+        }
+
+        MemberReview saved = memberReviewRepository.save(MemberReview.builder()
+                .taxiParty(party)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .rating(request.getRating())
+                .comment(request.getComment())
+                .build());
+
+        double delta = (request.getRating() - 3) * 1.0;
+        reviewee.updateMannerTemp(delta);
+
+        List<Participant> participants = participantRepository.findByTaxiPartyId(partyId);
+        String alias = buildAliasMap(participants).getOrDefault(userId, "익명");
+
+        return MemberReviewResponse.from(saved, alias);
+    }
+
+    @Transactional
+    public NoShowReportResponse submitNoShowReport(Long partyId, Long userId, NoShowReportRequest request) {
+        ensurePastPartyMember(partyId, userId);
+        ensureUserCanParticipate(userId);
+
+        if (userId.equals(request.getReportedUserId())) {
+            throw new CustomException(ErrorCode.CANNOT_REPORT_SELF);
+        }
+
+        if (!participantRepository.existsByTaxiPartyIdAndUserId(partyId, request.getReportedUserId())) {
+            throw new CustomException(ErrorCode.REVIEW_TARGET_NOT_IN_PARTY);
+        }
+
+        if (noShowReportRepository.existsByTaxiPartyIdAndReporterIdAndReportedUserId(
+                partyId, userId, request.getReportedUserId())) {
+            throw new CustomException(ErrorCode.NO_SHOW_ALREADY_REPORTED);
+        }
+
+        TaxiParty party = getParty(partyId);
+        User reporter = getUser(userId);
+        User reported = getUser(request.getReportedUserId());
+
+        NoShowReport report = noShowReportRepository.save(NoShowReport.builder()
+                .taxiParty(party)
+                .reporter(reporter)
+                .reportedUser(reported)
+                .reason(request.getReason())
+                .build());
+
+        long pendingCount = noShowReportRepository.countByTaxiPartyIdAndReportedUserIdAndStatus(
+                partyId, request.getReportedUserId(), NoShowReportStatus.PENDING);
+        if (pendingCount >= NO_SHOW_CONFIRM_THRESHOLD) {
+            confirmNoShowReports(partyId, request.getReportedUserId());
+            report = noShowReportRepository.findById(report.getId()).orElse(report);
+        }
+
+        return NoShowReportResponse.from(report);
+    }
+
+    private void confirmNoShowReports(Long partyId, Long reportedUserId) {
+        List<NoShowReport> pending = noShowReportRepository.findByTaxiPartyIdAndReportedUserId(partyId, reportedUserId)
+                .stream()
+                .filter(r -> r.getStatus() == NoShowReportStatus.PENDING)
+                .toList();
+
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        User reported = getUser(reportedUserId);
+        boolean alreadyConfirmed = noShowReportRepository
+                .countByTaxiPartyIdAndReportedUserIdAndStatus(
+                        partyId, reportedUserId, NoShowReportStatus.CONFIRMED) > 0;
+        if (alreadyConfirmed) {
+            pending.forEach(NoShowReport::confirm);
+            return;
+        }
+
+        pending.forEach(NoShowReport::confirm);
+        reported.recordNoShow(NO_SHOW_SUSPEND_DAYS);
+    }
+
+    private void ensurePastPartyMember(Long partyId, Long userId) {
+        TaxiParty party = getParty(partyId);
+        if (!participantRepository.existsByTaxiPartyIdAndUserId(partyId, userId)) {
+            throw new CustomException(ErrorCode.PARTY_NOT_JOINABLE);
+        }
+        if (party.getDepartureTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.PARTY_REVIEW_NOT_AVAILABLE);
+        }
+    }
+
+    private Map<Long, String> buildAliasMap(List<Participant> participants) {
+        Map<Long, String> map = new HashMap<>();
+        int idx = 1;
+        for (Participant p : participants) {
+            map.put(p.getUser().getId(), p.isHost() ? "방장" : "탑승자 " + idx);
+            if (!p.isHost()) {
+                idx++;
+            }
+        }
+        return map;
+    }
+
+    private TaxiParty getParty(Long partyId) {
+        return taxiPartyRepository.findById(partyId)
+                .orElseThrow(() -> new CustomException(ErrorCode.PARTY_NOT_FOUND));
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/com/yonta/util/TrustLevelUtil.java
+++ b/backend/src/main/java/com/yonta/util/TrustLevelUtil.java
@@ -1,0 +1,35 @@
+package com.yonta.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public final class TrustLevelUtil {
+
+    private TrustLevelUtil() {
+    }
+
+    public static TrustLevel resolve(double mannerTemp, Double averageRating) {
+        double score = mannerTemp;
+        if (averageRating != null && averageRating > 0) {
+            score = (mannerTemp * 0.7) + (averageRating * 7.0);
+        }
+        if (score < 30) return TrustLevel.DANGER;
+        if (score < 36) return TrustLevel.WARNING;
+        if (score < 40) return TrustLevel.NORMAL;
+        if (score < 45) return TrustLevel.GOOD;
+        return TrustLevel.EXCELLENT;
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum TrustLevel {
+        DANGER("위험", "text-red-600"),
+        WARNING("주의", "text-orange-500"),
+        NORMAL("보통", "text-blue-500"),
+        GOOD("우수", "text-emerald-600"),
+        EXCELLENT("최우수", "text-violet-600");
+
+        private final String label;
+        private final String colorClass;
+    }
+}

--- a/backend/src/main/resources/application-h2.yml
+++ b/backend/src/main/resources/application-h2.yml
@@ -1,0 +1,15 @@
+# 로컬 개발용 내장 DB (Supabase 없이 실행)
+spring:
+  datasource:
+    url: jdbc:h2:file:./data/yonta-dev;MODE=PostgreSQL;AUTO_SERVER=TRUE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: update

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,5 @@
 # 백엔드 API 서버 주소
 VITE_API_BASE_URL=http://localhost:8080
+
+# WebSocket (미설정 시 VITE_API_BASE_URL 사용)
+VITE_WS_BASE_URL=http://localhost:8080

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,12 +8,14 @@
       "name": "yonta-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.3.0",
         "axios": "^1.8.4",
         "dayjs": "^1.11.13",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hot-toast": "^2.5.2",
-        "react-router-dom": "^7.4.0"
+        "react-router-dom": "^7.4.0",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -58,7 +60,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1368,6 +1369,12 @@
         "win32"
       ]
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1726,7 +1733,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1852,7 +1858,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2006,8 +2011,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
@@ -2210,7 +2214,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2382,6 +2385,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2402,6 +2414,18 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2682,6 +2706,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2719,6 +2749,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2755,7 +2791,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2857,7 +2892,6 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -3203,7 +3237,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3335,7 +3368,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3401,12 +3433,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3416,7 +3453,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3489,6 +3525,12 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3544,6 +3586,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3587,6 +3649,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -3717,13 +3807,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3791,6 +3890,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,22 +11,24 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-router-dom": "^7.4.0",
+    "@stomp/stompjs": "^7.3.0",
     "axios": "^1.8.4",
     "dayjs": "^1.11.13",
-    "react-hot-toast": "^2.5.2"
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.5.2",
+    "react-router-dom": "^7.4.0",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.4.1",
-    "vite": "^6.2.4",
-    "tailwindcss": "^4.1.1",
-    "@tailwindcss/vite": "^4.1.1",
-    "eslint": "^9.22.0",
     "@eslint/js": "^9.22.0",
+    "@tailwindcss/vite": "^4.1.1",
+    "@vitejs/plugin-react": "^4.4.1",
+    "eslint": "^9.22.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
-    "globals": "^16.0.0"
+    "globals": "^16.0.0",
+    "tailwindcss": "^4.1.1",
+    "vite": "^6.2.4"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import { BrowserRouter, Routes, Route, useLocation, Navigate } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
-import Header from './components/common/Header';
+import { lazy, Suspense } from 'react';
+
+const Header = lazy(() => import('./components/common/Header'));
 import HomePage from './pages/HomePage';
 import AuthPage from './pages/AuthPage';
 import RideListPage from './pages/RideListPage';
@@ -14,7 +16,11 @@ function AppLayout() {
 
   return (
     <>
-      {!hideHeader && <Header />}
+      {!hideHeader && (
+        <Suspense fallback={null}>
+          <Header />
+        </Suspense>
+      )}
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/auth" element={<AuthPage />} />

--- a/frontend/src/api/chatApi.js
+++ b/frontend/src/api/chatApi.js
@@ -1,0 +1,7 @@
+import api from './axiosInstance';
+
+export const getPartyMessages = (partyId) =>
+  api.get(`/api/parties/${partyId}/messages`);
+
+export const sendPartyMessage = (partyId, content) =>
+  api.post(`/api/parties/${partyId}/messages`, { content });

--- a/frontend/src/api/notificationApi.js
+++ b/frontend/src/api/notificationApi.js
@@ -1,0 +1,9 @@
+import api from './axiosInstance';
+
+export const getNotifications = () => api.get('/api/notifications');
+
+export const getUnreadCount = () => api.get('/api/notifications/unread-count');
+
+export const markNotificationRead = (id) => api.patch(`/api/notifications/${id}/read`);
+
+export const markAllNotificationsRead = () => api.patch('/api/notifications/read-all');

--- a/frontend/src/api/trustApi.js
+++ b/frontend/src/api/trustApi.js
@@ -1,0 +1,9 @@
+import api from './axiosInstance';
+
+export const getTrustDashboard = () => api.get('/api/users/me/dashboard');
+
+export const submitMemberReview = (partyId, payload) =>
+  api.post(`/api/parties/${partyId}/member-reviews`, payload);
+
+export const submitNoShowReport = (partyId, payload) =>
+  api.post(`/api/parties/${partyId}/no-show-reports`, payload);

--- a/frontend/src/components/chat/PartyChatPanel.jsx
+++ b/frontend/src/components/chat/PartyChatPanel.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+import { usePartyChat } from '../../hooks/usePartyChat';
+
+export default function PartyChatPanel({ partyId, enabled = true }) {
+  const { messages, loading, sending, sendMessage } = usePartyChat(partyId, enabled);
+  const [input, setInput] = useState('');
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text) return;
+    setInput('');
+    await sendMessage(text);
+  };
+
+  return (
+    <section className="mt-4 rounded-2xl border border-slate-200 bg-slate-50/80 overflow-hidden">
+      <header className="px-4 py-2.5 border-b border-slate-200 bg-white flex items-center justify-between">
+        <p className="text-sm font-bold text-slate-800">파티 채팅</p>
+        <span className="text-[10px] font-semibold text-emerald-600 bg-emerald-50 px-2 py-0.5 rounded-full">
+          실시간
+        </span>
+      </header>
+
+      <div className="h-48 overflow-y-auto px-3 py-3 space-y-2">
+        {loading ? (
+          <p className="text-center text-xs text-slate-400 py-8">채팅 불러오는 중...</p>
+        ) : messages.length === 0 ? (
+          <p className="text-center text-xs text-slate-400 py-8">
+            파티원끼리만 대화할 수 있어요. 첫 메시지를 남겨보세요!
+          </p>
+        ) : (
+          messages.map((msg) => (
+            <div key={msg.id} className="flex flex-col gap-0.5">
+              <span className="text-[10px] font-semibold text-slate-500">{msg.senderAlias}</span>
+              <div className="inline-block self-start max-w-[85%] rounded-2xl rounded-tl-md bg-white border border-slate-200 px-3 py-2 text-sm text-slate-800 shadow-sm">
+                {msg.content}
+              </div>
+              <span className="text-[9px] text-slate-400">
+                {msg.sentAt?.slice(11, 16) ?? ''}
+              </span>
+            </div>
+          ))
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex gap-2 p-3 border-t border-slate-200 bg-white">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          maxLength={500}
+          placeholder="메시지 입력..."
+          className="flex-1 rounded-xl border border-slate-200 px-3 py-2.5 text-sm outline-none focus:border-blue-400"
+        />
+        <button
+          type="submit"
+          disabled={sending || !input.trim()}
+          className="shrink-0 px-4 py-2.5 rounded-xl bg-blue-700 text-white text-sm font-bold disabled:opacity-50"
+        >
+          전송
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -1,5 +1,6 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useState, useEffect } from 'react';
+import NotificationBell from './NotificationBell';
 
 const NAV = [
   { to: '/rides', label: '합승 찾기', icon: '🚕' },
@@ -43,7 +44,8 @@ export default function Header() {
           </Link>
 
           {userName ? (
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1">
+              <NotificationBell enabled />
               <span className="text-sm font-semibold text-slate-700 max-w-[8rem] truncate" title={userName}>
                 {userName}
               </span>

--- a/frontend/src/components/common/NotificationBell.jsx
+++ b/frontend/src/components/common/NotificationBell.jsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react';
+import { useRealtimeNotifications } from '../../hooks/useRealtimeNotifications';
+
+export default function NotificationBell({ enabled = true }) {
+  const {
+    notifications,
+    unreadCount,
+    open,
+    setOpen,
+    requestPushPermission,
+    handleMarkRead,
+    handleMarkAllRead,
+  } = useRealtimeNotifications(enabled);
+
+  useEffect(() => {
+    if (enabled && localStorage.getItem('accessToken')) {
+      requestPushPermission();
+    }
+  }, [enabled, requestPushPermission]);
+
+  if (!enabled || !localStorage.getItem('accessToken')) return null;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="relative p-2 rounded-xl hover:bg-slate-100 transition-colors"
+        aria-label="알림"
+      >
+        <span className="text-lg">🔔</span>
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 top-full mt-2 w-80 max-h-96 overflow-hidden rounded-2xl bg-white border border-slate-200 shadow-xl z-50">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+              <p className="text-sm font-bold text-slate-900">알림</p>
+              {unreadCount > 0 && (
+                <button
+                  type="button"
+                  onClick={handleMarkAllRead}
+                  className="text-xs text-blue-600 font-semibold hover:underline"
+                >
+                  모두 읽음
+                </button>
+              )}
+            </div>
+            <div className="max-h-72 overflow-y-auto">
+              {notifications.length === 0 ? (
+                <p className="text-center text-xs text-slate-400 py-8">알림이 없습니다</p>
+              ) : (
+                notifications.map((n) => (
+                  <button
+                    key={n.id}
+                    type="button"
+                    onClick={() => !n.read && handleMarkRead(n.id)}
+                    className={`w-full text-left px-4 py-3 border-b border-slate-50 hover:bg-slate-50 transition ${
+                      !n.read ? 'bg-blue-50/50' : ''
+                    }`}
+                  >
+                    <p className="text-sm font-semibold text-slate-800">{n.title}</p>
+                    <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{n.body}</p>
+                    <p className="text-[10px] text-slate-400 mt-1">
+                      {n.createdAt?.slice(0, 16).replace('T', ' ')}
+                    </p>
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/trust/TrustDashboard.jsx
+++ b/frontend/src/components/trust/TrustDashboard.jsx
@@ -1,0 +1,80 @@
+import { tempBg, tempColor, trustMeta } from '../../utils/mannerTemp';
+
+export default function TrustDashboard({ data }) {
+  if (!data) return null;
+
+  const level = trustMeta(data.trustLevel);
+  const tempPercent = Math.min(100, Math.max(0, data.mannerTemp));
+
+  return (
+    <section className="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-900/[0.04] mb-6">
+      <div className="flex items-start justify-between gap-4 mb-4">
+        <div>
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wide">신뢰 지수</p>
+          <p className={`text-2xl font-extrabold mt-1 ${level.color}`}>{level.label}</p>
+        </div>
+        <div className={`px-3 py-1.5 rounded-full text-xs font-bold ring-1 ${level.bg} ${level.color} ${level.ring}`}>
+          {data.trustLevelLabel || level.label}
+        </div>
+      </div>
+
+      {data.suspended && (
+        <div className="mb-4 rounded-xl bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">
+          이용 정지 중입니다.
+          {data.suspendedUntil && (
+            <span className="block text-xs mt-1 text-red-500">
+              해제 예정: {data.suspendedUntil.slice(0, 16).replace('T', ' ')}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="mb-4">
+        <div className="flex items-end justify-between mb-2">
+          <span className="text-sm font-semibold text-slate-700">매너 온도</span>
+          <span className={`text-2xl font-black tabular-nums ${tempColor(data.mannerTemp)}`}>
+            {data.mannerTemp.toFixed(1)}°
+          </span>
+        </div>
+        <div className="h-3 rounded-full bg-slate-100 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${tempBg(data.mannerTemp)}`}
+            style={{ width: `${tempPercent}%` }}
+          />
+        </div>
+        <p className="text-[11px] text-slate-400 mt-1.5">36.5° 기본 · 평가·노쇼에 따라 변동</p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <StatBox label="받은 평가" value={data.totalReviewsReceived} sub={data.averageRatingReceived != null ? `평균 ${data.averageRatingReceived.toFixed(1)}점` : '-'} />
+        <StatBox label="참여 파티" value={data.totalPartiesJoined} />
+        <StatBox label="노쇼 확정" value={data.noShowCount} warn={data.noShowCount > 0} />
+      </div>
+
+      {data.recentReviewsReceived?.length > 0 && (
+        <div className="mt-5 pt-4 border-t border-slate-100">
+          <p className="text-xs font-bold text-slate-500 mb-2">최근 받은 평가</p>
+          <div className="space-y-2 max-h-32 overflow-y-auto">
+            {data.recentReviewsReceived.slice(0, 5).map((r) => (
+              <div key={r.id} className="rounded-lg bg-slate-50 px-3 py-2 text-xs">
+                <span className="font-bold text-yellow-500">{'★'.repeat(r.rating)}</span>
+                <span className="text-slate-500 ml-2">{r.reviewerAlias}</span>
+                {r.comment && <p className="text-slate-600 mt-1 line-clamp-1">{r.comment}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function StatBox({ label, value, sub, warn }) {
+  return (
+    <div className={`rounded-xl px-2 py-2.5 ${warn ? 'bg-red-50' : 'bg-slate-50'}`}>
+      <p className="text-[10px] text-slate-400 font-semibold">{label}</p>
+      <p className={`text-lg font-extrabold ${warn ? 'text-red-600' : 'text-slate-800'}`}>{value}</p>
+      {sub && <p className="text-[10px] text-slate-400 mt-0.5">{sub}</p>}
+    </div>
+  );
+}

--- a/frontend/src/hooks/usePartyChat.js
+++ b/frontend/src/hooks/usePartyChat.js
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { getPartyMessages, sendPartyMessage } from '../api/chatApi';
+import {
+  createStompClient,
+  sendChatMessage,
+  subscribePartyChat,
+} from '../lib/websocket';
+
+export function usePartyChat(partyId, enabled = true) {
+  const [messages, setMessages] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const clientRef = useRef(null);
+  const subsRef = useRef(null);
+
+  const loadHistory = useCallback(async () => {
+    if (!partyId) return;
+    setLoading(true);
+    try {
+      const res = await getPartyMessages(partyId);
+      setMessages(res.data.data || []);
+    } finally {
+      setLoading(false);
+    }
+  }, [partyId]);
+
+  useEffect(() => {
+    if (!enabled || !partyId || !localStorage.getItem('accessToken')) return undefined;
+    loadHistory();
+
+    const client = createStompClient({
+      onConnect: () => {
+        subsRef.current = subscribePartyChat(client, partyId, (msg) => {
+          setMessages((prev) => {
+            if (prev.some((m) => m.id === msg.id)) return prev;
+            return [...prev, msg];
+          });
+        });
+      },
+    });
+    if (!client) return undefined;
+    clientRef.current = client;
+    client.activate();
+
+    return () => {
+      subsRef.current?.unsubscribe();
+      client.deactivate();
+    };
+  }, [partyId, enabled, loadHistory]);
+
+  const sendMessage = async (content) => {
+    if (!content.trim() || !partyId) return;
+    setSending(true);
+    try {
+      const client = clientRef.current;
+      if (client?.connected) {
+        sendChatMessage(client, partyId, content.trim());
+      } else {
+        await sendPartyMessage(partyId, content.trim());
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return { messages, loading, sending, sendMessage, loadHistory };
+}

--- a/frontend/src/hooks/usePartyRealtime.js
+++ b/frontend/src/hooks/usePartyRealtime.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+import { createStompClient, subscribePartyUpdate } from '../lib/websocket';
+
+export function usePartyRealtime(partyId, onUpdate, enabled = true) {
+  const callbackRef = useRef(onUpdate);
+  callbackRef.current = onUpdate;
+
+  useEffect(() => {
+    if (!enabled || !partyId || !localStorage.getItem('accessToken')) return undefined;
+
+    let subscription;
+    const client = createStompClient({
+      onConnect: () => {
+        subscription = subscribePartyUpdate(client, partyId, (event) => {
+          callbackRef.current?.(event);
+        });
+      },
+    });
+    if (!client) return undefined;
+    client.activate();
+
+    return () => {
+      subscription?.unsubscribe();
+      client.deactivate();
+    };
+  }, [partyId, enabled]);
+}

--- a/frontend/src/hooks/useRealtimeNotifications.js
+++ b/frontend/src/hooks/useRealtimeNotifications.js
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import { getNotifications, getUnreadCount, markAllNotificationsRead, markNotificationRead } from '../api/notificationApi';
+import { createStompClient, subscribeNotifications } from '../lib/websocket';
+
+const NOTIFICATION_LABELS = {
+  MEMBER_JOINED: '👋 참여',
+  MEMBER_LEFT: '🚪 탈퇴',
+  DEPARTURE_SOON: '⏰ 출발 임박',
+  PARTY_DEPARTED: '🚕 출발',
+  PARTY_SETTLED: '✅ 종료',
+};
+
+export function useRealtimeNotifications(enabled = true) {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const clientRef = useRef(null);
+  const subsRef = useRef(null);
+
+  const refresh = useCallback(async () => {
+    if (!localStorage.getItem('accessToken')) return;
+    try {
+      const [listRes, countRes] = await Promise.all([getNotifications(), getUnreadCount()]);
+      setNotifications(listRes.data.data || []);
+      setUnreadCount(countRes.data.data?.count ?? 0);
+    } catch {
+      /* ignore when logged out */
+    }
+  }, []);
+
+  const handleIncoming = useCallback((notification) => {
+    setNotifications((prev) => [notification, ...prev.filter((n) => n.id !== notification.id)]);
+    setUnreadCount((c) => c + 1);
+    const prefix = NOTIFICATION_LABELS[notification.type] || '🔔';
+    toast(`${prefix} ${notification.title}`, { duration: 5000 });
+    if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
+      new Notification(notification.title, { body: notification.body });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !localStorage.getItem('accessToken')) return undefined;
+    refresh();
+
+    const client = createStompClient({
+      onConnect: () => {
+        subsRef.current = subscribeNotifications(client, handleIncoming);
+      },
+    });
+    if (!client) return undefined;
+    clientRef.current = client;
+    client.activate();
+
+    return () => {
+      subsRef.current?.unsubscribe();
+      client.deactivate();
+    };
+  }, [enabled, refresh, handleIncoming]);
+
+  const requestPushPermission = useCallback(async () => {
+    if (!('Notification' in window)) return false;
+    if (Notification.permission === 'granted') return true;
+    if (Notification.permission === 'denied') return false;
+    const result = await Notification.requestPermission();
+    return result === 'granted';
+  }, []);
+
+  const handleMarkRead = async (id) => {
+    await markNotificationRead(id);
+    setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read: true } : n)));
+    setUnreadCount((c) => Math.max(0, c - 1));
+  };
+
+  const handleMarkAllRead = async () => {
+    await markAllNotificationsRead();
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    setUnreadCount(0);
+  };
+
+  return {
+    notifications,
+    unreadCount,
+    open,
+    setOpen,
+    refresh,
+    requestPushPermission,
+    handleMarkRead,
+    handleMarkAllRead,
+  };
+}

--- a/frontend/src/lib/websocket.js
+++ b/frontend/src/lib/websocket.js
@@ -1,0 +1,53 @@
+import { Client } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+const WS_BASE = import.meta.env.VITE_WS_BASE_URL
+  || import.meta.env.VITE_API_BASE_URL
+  || 'http://localhost:8080';
+
+export function createStompClient({ onConnect, onDisconnect, onError } = {}) {
+  const token = localStorage.getItem('accessToken');
+  if (!token) return null;
+
+  const client = new Client({
+    webSocketFactory: () => new SockJS(`${WS_BASE}/ws`),
+    connectHeaders: {
+      Authorization: `Bearer ${token}`,
+    },
+    reconnectDelay: 5000,
+    heartbeatIncoming: 10000,
+    heartbeatOutgoing: 10000,
+    onConnect,
+    onDisconnect,
+    onStompError: (frame) => {
+      onError?.(frame);
+    },
+  });
+
+  return client;
+}
+
+export function subscribePartyChat(client, partyId, onMessage) {
+  return client.subscribe(`/topic/party.${partyId}.chat`, (frame) => {
+    onMessage(JSON.parse(frame.body));
+  });
+}
+
+export function subscribePartyUpdate(client, partyId, onUpdate) {
+  return client.subscribe(`/topic/party.${partyId}.update`, (frame) => {
+    onUpdate(JSON.parse(frame.body));
+  });
+}
+
+export function subscribeNotifications(client, onNotification) {
+  return client.subscribe('/user/queue/notifications', (frame) => {
+    onNotification(JSON.parse(frame.body));
+  });
+}
+
+export function sendChatMessage(client, partyId, content) {
+  client.publish({
+    destination: `/app/party.${partyId}.chat`,
+    body: JSON.stringify({ content }),
+  });
+}

--- a/frontend/src/pages/MyPartyPage.jsx
+++ b/frontend/src/pages/MyPartyPage.jsx
@@ -2,29 +2,41 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import RideList from '../components/ride/RideList';
+import TrustDashboard from '../components/trust/TrustDashboard';
 import {
-  getMyParties, getMyPartyHistory, getPartyDetail, leaveParty, dissolveParty, transferHost, submitPartyReview,
+  getMyParties, getPartyDetail, leaveParty, dissolveParty, transferHost, submitPartyReview,
 } from '../api/rideApi';
+import { getTrustDashboard, submitMemberReview, submitNoShowReport } from '../api/trustApi';
 import { LOCATIONS } from '../utils/constants';
+import PartyChatPanel from '../components/chat/PartyChatPanel';
+import { usePartyRealtime } from '../hooks/usePartyRealtime';
 
 export default function MyPartyPage() {
   const navigate = useNavigate();
+  const [dashboard, setDashboard] = useState(null);
   const [activeParties, setActiveParties] = useState([]);
   const [historyParties, setHistoryParties] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState('active');
+  const [tab, setTab] = useState('dashboard');
   const [selected, setSelected] = useState(null);
   const [actionLoading, setActionLoading] = useState(false);
   const [reviewTarget, setReviewTarget] = useState(null);
   const [reviewScore, setReviewScore] = useState(5);
   const [reviewComment, setReviewComment] = useState('');
+  const [memberReviewTarget, setMemberReviewTarget] = useState(null);
+  const [memberScore, setMemberScore] = useState(5);
+  const [memberComment, setMemberComment] = useState('');
+  const [noShowTarget, setNoShowTarget] = useState(null);
+  const [noShowReason, setNoShowReason] = useState('');
 
   const loadMyPage = useCallback(async () => {
     setLoading(true);
     try {
-      const [activeRes, historyRes] = await Promise.all([getMyParties(), getMyPartyHistory()]);
+      const [dashRes, activeRes] = await Promise.all([getTrustDashboard(), getMyParties()]);
+      const dash = dashRes.data.data;
+      setDashboard(dash);
       setActiveParties(activeRes.data.data || []);
-      setHistoryParties(historyRes.data.data || []);
+      setHistoryParties(dash?.partyHistory || []);
     } catch (err) {
       toast.error(err.response?.data?.message || '마이페이지를 불러오지 못했습니다.');
     } finally {
@@ -50,6 +62,17 @@ export default function MyPartyPage() {
       toast.error(err.response?.data?.message || '상세 정보를 불러오지 못했습니다.');
     }
   };
+
+  usePartyRealtime(
+    selected?.id,
+    async () => {
+      if (!selected?.id) return;
+      const res = await getPartyDetail(selected.id);
+      setSelected(res.data.data);
+      await loadMyPage();
+    },
+    Boolean(selected?.id),
+  );
 
   const handleLeave = async () => {
     if (!selected?.id) return;
@@ -111,11 +134,49 @@ export default function MyPartyPage() {
         rating: reviewScore,
         comment: reviewComment.trim(),
       });
-      toast.success('평가를 저장했습니다.');
+      toast.success('파티 평가를 저장했습니다.');
       setReviewTarget(null);
       await loadMyPage();
     } catch (err) {
       toast.error(err.response?.data?.message || '평가 저장에 실패했습니다.');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleSubmitMemberReview = async () => {
+    if (!memberReviewTarget) return;
+    setActionLoading(true);
+    try {
+      await submitMemberReview(memberReviewTarget.partyId, {
+        revieweeId: memberReviewTarget.userId,
+        rating: memberScore,
+        comment: memberComment.trim(),
+      });
+      toast.success('멤버 평가가 저장되었습니다.');
+      setMemberReviewTarget(null);
+      await loadMyPage();
+    } catch (err) {
+      toast.error(err.response?.data?.message || '멤버 평가에 실패했습니다.');
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleSubmitNoShow = async () => {
+    if (!noShowTarget || !noShowReason.trim()) return;
+    setActionLoading(true);
+    try {
+      const res = await submitNoShowReport(noShowTarget.partyId, {
+        reportedUserId: noShowTarget.userId,
+        reason: noShowReason.trim(),
+      });
+      toast.success(res.data.message || '노쇼 신고가 접수되었습니다.');
+      setNoShowTarget(null);
+      setNoShowReason('');
+      await loadMyPage();
+    } catch (err) {
+      toast.error(err.response?.data?.message || '노쇼 신고에 실패했습니다.');
     } finally {
       setActionLoading(false);
     }
@@ -126,199 +187,255 @@ export default function MyPartyPage() {
       <div className="max-w-3xl mx-auto px-4 py-8">
         <div className="mb-6">
           <h2 className="text-2xl font-extrabold text-slate-900 mb-1 tracking-tight">마이페이지</h2>
-          <p className="text-sm text-slate-500 font-medium">진행중 파티와 지난 파티 기록, 평가를 관리하세요.</p>
+          <p className="text-sm text-slate-500 font-medium">신뢰 지수, 이용 내역, 평가·노쇼 신고를 관리하세요.</p>
         </div>
 
-        <div className="grid grid-cols-2 gap-2 mb-6 p-1 rounded-2xl bg-slate-100/90 ring-1 ring-slate-200/60">
-          <button
-            type="button"
-            onClick={() => setTab('active')}
-            className={`rounded-xl py-3 text-sm font-bold transition-all ${
-              tab === 'active'
-                ? 'bg-white text-slate-900 shadow-md shadow-slate-900/10 ring-1 ring-slate-200/80'
-                : 'text-slate-500 hover:text-slate-700'
-            }`}
-          >
-            진행중 {activeParties.length}
-          </button>
-          <button
-            type="button"
-            onClick={() => setTab('history')}
-            className={`rounded-xl py-3 text-sm font-bold transition-all ${
-              tab === 'history'
-                ? 'bg-white text-slate-900 shadow-md shadow-slate-900/10 ring-1 ring-slate-200/80'
-                : 'text-slate-500 hover:text-slate-700'
-            }`}
-          >
-            지난 기록 {historyParties.length}
-          </button>
-        </div>
-
-      {loading ? (
-        <div className="py-16 text-center text-gray-400">불러오는 중...</div>
-      ) : tab === 'active' ? (
-        <RideList parties={activeParties} onCardClick={(p) => openParty(p.id)} />
-      ) : (
-        <div className="space-y-3">
-          {historyParties.length === 0 ? (
-            <div className="rounded-2xl border border-gray-100 bg-white py-10 text-center text-gray-400">
-              지난 파티 기록이 아직 없습니다.
-            </div>
-          ) : historyParties.map((item) => (
-            <HistoryCard key={item.party.id} item={item} onReview={() => openReviewModal(item)} />
+        <div className="grid grid-cols-3 gap-2 mb-6 p-1 rounded-2xl bg-slate-100/90 ring-1 ring-slate-200/60">
+          {[
+            { key: 'dashboard', label: '대시보드' },
+            { key: 'active', label: `진행중 ${activeParties.length}` },
+            { key: 'history', label: `이용내역 ${historyParties.length}` },
+          ].map(({ key, label }) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setTab(key)}
+              className={`rounded-xl py-2.5 text-xs sm:text-sm font-bold transition-all ${
+                tab === key
+                  ? 'bg-white text-slate-900 shadow-md shadow-slate-900/10 ring-1 ring-slate-200/80'
+                  : 'text-slate-500 hover:text-slate-700'
+              }`}
+            >
+              {label}
+            </button>
           ))}
         </div>
-      )}
 
-      {selected && (
-        <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-[2px] z-[60] flex items-end justify-center" onClick={() => setSelected(null)}>
-          <div className="w-full max-w-3xl bg-white rounded-t-3xl p-5 pb-7 border-t border-slate-100 shadow-2xl" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center justify-between mb-3">
-              <p className="text-lg font-bold text-gray-900">내 파티 상세</p>
-              {selected.isHost && (
-                <span className="text-xs font-bold px-2.5 py-1 rounded-full bg-yellow-100 text-yellow-700 border border-yellow-200">
-                  방장
-                </span>
-              )}
-            </div>
-            <p className="text-sm text-gray-500 mb-4">
-              인원: {selected.currentCount}/{selected.maxCount}명
-            </p>
-
-            {/* 멤버 목록 (상세 API에서 members 제공) */}
-            <div className="space-y-2 mb-4">
-              {(selected.members ?? []).map((member) => (
-                <div key={member.userId} className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5">
-                  <div className="flex items-center gap-2">
-                    <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-blue-700 flex items-center justify-center text-white text-xs font-bold">
-                      {member.alias?.slice(-1) ?? '?'}
-                    </div>
-                    <span className="text-sm font-semibold text-gray-700">{member.alias}</span>
-                    {member.isHost && (
-                      <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-yellow-100 text-yellow-700">방장</span>
-                    )}
-                  </div>
-                  {selected.isHost && !member.isHost && (
-                    <button
-                      onClick={() => handleTransferHost(member.userId)}
-                      disabled={actionLoading}
-                      className="text-xs font-semibold px-3 py-1.5 rounded-lg border border-blue-200 text-blue-600 hover:bg-blue-50 disabled:opacity-50"
-                    >
-                      방장 위임
-                    </button>
-                  )}
-                </div>
-              ))}
-            </div>
-
-            {/* 방장 + 혼자: 해산 버튼 */}
-            {selected.isHost && selected.currentCount === 1 && (
-              <button
-                onClick={handleDissolve}
-                disabled={actionLoading}
-                className="w-full py-3 rounded-xl bg-red-50 text-red-600 font-semibold border border-red-200 hover:bg-red-100 disabled:opacity-60"
-              >
-                {actionLoading ? '처리 중...' : '파티 해산'}
-              </button>
-            )}
-
-            {/* 방장 + 여러명: 위임 안내 + 나가기 */}
-            {selected.isHost && selected.currentCount > 1 && (
-              <div className="space-y-2">
-                <p className="text-xs text-gray-400 text-center">다른 멤버에게 방장을 위임한 후 나갈 수 있습니다.</p>
+        {loading ? (
+          <div className="py-16 text-center text-gray-400">불러오는 중...</div>
+        ) : tab === 'dashboard' ? (
+          <TrustDashboard data={dashboard} />
+        ) : tab === 'active' ? (
+          <RideList parties={activeParties} onCardClick={(p) => openParty(p.id)} />
+        ) : (
+          <div className="space-y-3">
+            {historyParties.length === 0 ? (
+              <div className="rounded-2xl border border-gray-100 bg-white py-10 text-center text-gray-400">
+                지난 파티 기록이 아직 없습니다.
               </div>
-            )}
-
-            {/* 게스트: 나가기 버튼 */}
-            {!selected.isHost && (
-              <button
-                onClick={handleLeave}
-                disabled={actionLoading}
-                className="w-full py-3 rounded-xl bg-red-50 text-red-600 font-semibold border border-red-200 hover:bg-red-100 disabled:opacity-60"
-              >
-                {actionLoading ? '처리 중...' : '파티 나가기'}
-              </button>
-            )}
+            ) : historyParties.map((item) => (
+              <HistoryCard
+                key={item.party.id}
+                item={item}
+                onPartyReview={() => openReviewModal(item)}
+                onMemberReview={(member) => setMemberReviewTarget({
+                  partyId: item.party.id,
+                  userId: member.userId,
+                  alias: member.alias,
+                })}
+                onNoShow={(member) => setNoShowTarget({
+                  partyId: item.party.id,
+                  userId: member.userId,
+                  alias: member.alias,
+                })}
+              />
+            ))}
           </div>
-        </div>
-      )}
+        )}
 
-      {reviewTarget && (
-        <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-[2px] z-[70] flex items-end justify-center" onClick={() => setReviewTarget(null)}>
-          <div className="w-full max-w-2xl bg-white rounded-t-3xl p-5 pb-7 border-t border-slate-100 shadow-2xl" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-lg font-bold text-gray-900 mb-1">지난 파티 평가</h3>
-            <p className="text-sm text-gray-500 mb-4">
-              {reviewTarget.party.departureTime.slice(0, 16).replace('T', ' ')}
-            </p>
+        {selected && (
+          <PartyDetailModal
+            selected={selected}
+            actionLoading={actionLoading}
+            onClose={() => setSelected(null)}
+            onLeave={handleLeave}
+            onDissolve={handleDissolve}
+            onTransferHost={handleTransferHost}
+          />
+        )}
 
-            <div className="flex gap-1 mb-4">
-              {[1, 2, 3, 4, 5].map((n) => (
-                <button
-                  key={n}
-                  onClick={() => setReviewScore(n)}
-                  className={`text-2xl ${n <= reviewScore ? 'text-yellow-400' : 'text-gray-200'}`}
-                >
-                  ★
-                </button>
-              ))}
-            </div>
+        {reviewTarget && (
+          <RatingModal
+            title="파티 전체 평가"
+            score={reviewScore}
+            comment={reviewComment}
+            onScore={setReviewScore}
+            onComment={setReviewComment}
+            onClose={() => setReviewTarget(null)}
+            onSubmit={handleSubmitReview}
+            loading={actionLoading}
+          />
+        )}
 
-            <textarea
-              rows={4}
-              value={reviewComment}
-              onChange={(e) => setReviewComment(e.target.value)}
-              maxLength={300}
-              placeholder="탑승 경험을 남겨주세요. (선택)"
-              className="w-full rounded-xl border border-gray-200 p-3 text-sm outline-none focus:border-blue-400"
-            />
-            <p className="text-xs text-gray-400 mt-1 text-right">{reviewComment.length}/300</p>
+        {memberReviewTarget && (
+          <RatingModal
+            title={`${memberReviewTarget.alias} 평가`}
+            score={memberScore}
+            comment={memberComment}
+            onScore={setMemberScore}
+            onComment={setMemberComment}
+            onClose={() => setMemberReviewTarget(null)}
+            onSubmit={handleSubmitMemberReview}
+            loading={actionLoading}
+          />
+        )}
 
-            <div className="flex gap-2 mt-4">
-              <button
-                onClick={() => setReviewTarget(null)}
-                className="flex-1 py-3 rounded-xl border border-gray-200 text-gray-600 font-semibold"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleSubmitReview}
-                disabled={actionLoading}
-                className="flex-1 py-3 rounded-xl bg-blue-700 text-white font-semibold disabled:opacity-60"
-              >
-                평가 저장
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+        {noShowTarget && (
+          <NoShowModal
+            target={noShowTarget}
+            reason={noShowReason}
+            onReason={setNoShowReason}
+            onClose={() => { setNoShowTarget(null); setNoShowReason(''); }}
+            onSubmit={handleSubmitNoShow}
+            loading={actionLoading}
+          />
+        )}
       </div>
     </div>
   );
 }
 
-function HistoryCard({ item, onReview }) {
+function HistoryCard({ item, onPartyReview, onMemberReview, onNoShow }) {
   const party = item.party;
   return (
     <div className="rounded-2xl border border-slate-200/80 bg-white/95 p-4 shadow-sm shadow-slate-900/[0.04]">
       <p className="text-xs text-gray-400 mb-1">{party.departureTime.slice(0, 16).replace('T', ' ')}</p>
       <p className="text-sm font-bold text-gray-900 mb-1">
-        {labelOf(party.departure)} {'->'} {labelOf(party.destination)}
+        {labelOf(party.departure)} → {labelOf(party.destination)}
       </p>
       <p className="text-xs text-gray-500 mb-3">인원 {party.currentCount}/{party.maxCount}명</p>
 
-      {item.reviewed ? (
-        <div className="rounded-xl bg-green-50 border border-green-100 px-3 py-2 text-sm text-green-700">
-          평가 완료 · {item.myRating}점
-          {item.myComment ? ` · ${item.myComment}` : ''}
+      {item.receivedReviews?.length > 0 && (
+        <div className="mb-3 rounded-xl bg-amber-50 border border-amber-100 px-3 py-2">
+          <p className="text-xs font-bold text-amber-800 mb-1">받은 평가</p>
+          {item.receivedReviews.map((r) => (
+            <p key={r.id} className="text-xs text-amber-900">
+              {'★'.repeat(r.rating)} {r.reviewerAlias}
+              {r.comment ? ` · ${r.comment}` : ''}
+            </p>
+          ))}
         </div>
-      ) : (
+      )}
+
+      {!item.reviewed && (
         <button
-          onClick={onReview}
-          className="w-full py-2.5 rounded-xl border border-blue-200 bg-blue-50 text-blue-700 text-sm font-semibold hover:bg-blue-100"
+          type="button"
+          onClick={onPartyReview}
+          className="w-full mb-2 py-2 rounded-xl border border-blue-200 bg-blue-50 text-blue-700 text-sm font-semibold hover:bg-blue-100"
         >
-          평가 남기기
+          파티 평가 남기기
         </button>
       )}
+      {item.reviewed && (
+        <div className="mb-2 rounded-xl bg-green-50 border border-green-100 px-3 py-2 text-sm text-green-700">
+          파티 평가 완료 · {item.myRating}점
+        </div>
+      )}
+
+      {(item.otherMembers ?? []).length > 0 && (
+        <div className="space-y-2 pt-2 border-t border-slate-100">
+          <p className="text-xs font-bold text-slate-500">함께한 멤버</p>
+          {item.otherMembers.map((m) => (
+            <div key={m.userId} className="flex flex-wrap gap-2">
+              <span className="text-sm font-medium text-slate-700 flex-1">{m.alias}</span>
+              {!m.reviewedByMe && (
+                <button
+                  type="button"
+                  onClick={() => onMemberReview(m)}
+                  className="text-xs px-2.5 py-1 rounded-lg bg-blue-50 text-blue-700 font-semibold"
+                >
+                  평가
+                </button>
+              )}
+              {m.reviewedByMe && (
+                <span className="text-xs text-green-600 font-semibold">평가완료</span>
+              )}
+              {!m.noShowReportedByMe && (
+                <button
+                  type="button"
+                  onClick={() => onNoShow(m)}
+                  className="text-xs px-2.5 py-1 rounded-lg bg-red-50 text-red-600 font-semibold"
+                >
+                  노쇼 신고
+                </button>
+              )}
+              {m.noShowReportedByMe && (
+                <span className="text-xs text-slate-400">신고완료</span>
+              )}
+            </div>
+          ))}
+          <p className="text-[10px] text-slate-400">노쇼는 파티원 2명 신고 시 확정 · 누적 2회 시 7일 이용정지</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PartyDetailModal({ selected, actionLoading, onClose, onLeave, onDissolve, onTransferHost }) {
+  return (
+    <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-[2px] z-[60] flex items-end justify-center" onClick={onClose}>
+      <div className="w-full max-w-3xl bg-white rounded-t-3xl p-5 pb-7 border-t border-slate-100 shadow-2xl max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-lg font-bold text-gray-900">내 파티 상세</p>
+          {selected.isHost && (
+            <span className="text-xs font-bold px-2.5 py-1 rounded-full bg-yellow-100 text-yellow-700 border border-yellow-200">방장</span>
+          )}
+        </div>
+        <p className="text-sm text-gray-500 mb-4">인원: {selected.currentCount}/{selected.maxCount}명</p>
+        <div className="space-y-2 mb-4">
+          {(selected.members ?? []).map((member) => (
+            <div key={member.userId} className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5">
+              <span className="text-sm font-semibold text-gray-700">{member.alias}</span>
+              {selected.isHost && !member.isHost && (
+                <button type="button" onClick={() => onTransferHost(member.userId)} disabled={actionLoading} className="text-xs font-semibold px-3 py-1.5 rounded-lg border border-blue-200 text-blue-600">방장 위임</button>
+              )}
+            </div>
+          ))}
+        </div>
+        {selected.isHost && selected.currentCount === 1 && (
+          <button type="button" onClick={onDissolve} disabled={actionLoading} className="w-full py-3 rounded-xl bg-red-50 text-red-600 font-semibold border border-red-200 mb-3">파티 해산</button>
+        )}
+        {!selected.isHost && (
+          <button type="button" onClick={onLeave} disabled={actionLoading} className="w-full py-3 rounded-xl bg-red-50 text-red-600 font-semibold border border-red-200 mb-3">파티 나가기</button>
+        )}
+        <PartyChatPanel partyId={selected.id} />
+      </div>
+    </div>
+  );
+}
+
+function RatingModal({ title, score, comment, onScore, onComment, onClose, onSubmit, loading }) {
+  return (
+    <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-[2px] z-[70] flex items-end justify-center" onClick={onClose}>
+      <div className="w-full max-w-2xl bg-white rounded-t-3xl p-5 pb-7" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-lg font-bold text-gray-900 mb-4">{title}</h3>
+        <div className="flex gap-1 mb-4">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button key={n} type="button" onClick={() => onScore(n)} className={`text-2xl ${n <= score ? 'text-yellow-400' : 'text-gray-200'}`}>★</button>
+          ))}
+        </div>
+        <textarea rows={3} value={comment} onChange={(e) => onComment(e.target.value)} maxLength={300} placeholder="메모 (선택)" className="w-full rounded-xl border border-gray-200 p-3 text-sm outline-none focus:border-blue-400" />
+        <div className="flex gap-2 mt-4">
+          <button type="button" onClick={onClose} className="flex-1 py-3 rounded-xl border border-gray-200 text-gray-600 font-semibold">취소</button>
+          <button type="button" onClick={onSubmit} disabled={loading} className="flex-1 py-3 rounded-xl bg-blue-700 text-white font-semibold disabled:opacity-60">저장</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NoShowModal({ target, reason, onReason, onClose, onSubmit, loading }) {
+  return (
+    <div className="fixed inset-0 bg-slate-900/40 backdrop-blur-[2px] z-[70] flex items-end justify-center" onClick={onClose}>
+      <div className="w-full max-w-2xl bg-white rounded-t-3xl p-5 pb-7" onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-lg font-bold text-gray-900 mb-1">노쇼 신고</h3>
+        <p className="text-sm text-gray-500 mb-4">{target.alias} · 정당한 사유 없이 불참한 경우에만 신고해주세요.</p>
+        <textarea rows={4} value={reason} onChange={(e) => onReason(e.target.value)} maxLength={500} placeholder="신고 사유를 입력해주세요 (필수)" className="w-full rounded-xl border border-gray-200 p-3 text-sm outline-none focus:border-red-400" />
+        <div className="flex gap-2 mt-4">
+          <button type="button" onClick={onClose} className="flex-1 py-3 rounded-xl border border-gray-200 text-gray-600 font-semibold">취소</button>
+          <button type="button" onClick={onSubmit} disabled={loading || !reason.trim()} className="flex-1 py-3 rounded-xl bg-red-600 text-white font-semibold disabled:opacity-60">신고하기</button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -326,3 +443,4 @@ function HistoryCard({ item, onReview }) {
 function labelOf(key) {
   return LOCATIONS.find((l) => l.key === key)?.label || key;
 }
+

--- a/frontend/src/pages/RideListPage.jsx
+++ b/frontend/src/pages/RideListPage.jsx
@@ -6,9 +6,9 @@ import RideList from '../components/ride/RideList';
 import { getAvailableParties, getPartyDetail, joinParty, leaveParty } from '../api/rideApi';
 import { getNextDays, getDateLabel, formatDate } from '../utils/formatters';
 import toast from 'react-hot-toast';
+import { usePartyRealtime } from '../hooks/usePartyRealtime';
 
 const CAMPUS_KEY = 'CAMPUS';
-const POLLING_MS = 3000;
 const PERIODS = [
   { key: 'DAWN', label: '새벽', icon: '🌙', startHour: 0, endHour: 5 },
   { key: 'MORNING', label: '오전', icon: '🌅', startHour: 6, endHour: 11 },
@@ -90,12 +90,18 @@ export default function RideListPage() {
   useEffect(() => {
     if (!selectedPartyId) return undefined;
     loadPartyDetail(selectedPartyId);
-    const id = setInterval(() => {
-      loadPartyDetail(selectedPartyId);
-      loadParties();
-    }, POLLING_MS);
-    return () => clearInterval(id);
-  }, [selectedPartyId, loadPartyDetail, loadParties]);
+  }, [selectedPartyId, loadPartyDetail]);
+
+  usePartyRealtime(
+    selectedPartyId,
+    () => {
+      if (selectedPartyId) {
+        loadPartyDetail(selectedPartyId);
+        loadParties();
+      }
+    },
+    Boolean(selectedPartyId),
+  );
 
   const filteredByBase = useMemo(() => {
     return parties.filter((p) => {
@@ -371,7 +377,7 @@ function PartyDetailSheet({ party, loading, actionLoading, onClose, onJoin, onLe
       >
         <div className="w-12 h-1.5 bg-slate-200 rounded-full mx-auto mb-4" />
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-lg font-bold text-gray-900">파티 상세 (실시간 갱신)</h3>
+          <h3 className="text-lg font-bold text-gray-900">파티 상세</h3>
           <button className="text-gray-400 hover:text-gray-600" onClick={onClose}>닫기</button>
         </div>
 
@@ -384,7 +390,7 @@ function PartyDetailSheet({ party, loading, actionLoading, onClose, onJoin, onLe
               <p className="text-2xl font-extrabold text-slate-900 tabular-nums">
                 {party.currentCount}/{party.maxCount}명
               </p>
-              <p className="text-xs text-blue-600/80 mt-1 font-medium">3초마다 자동 갱신됩니다.</p>
+              <p className="text-xs text-blue-600/80 mt-1 font-medium">참여·탈퇴 시 실시간 반영됩니다.</p>
             </div>
 
             <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">

--- a/frontend/src/utils/mannerTemp.js
+++ b/frontend/src/utils/mannerTemp.js
@@ -1,0 +1,23 @@
+export const TRUST_LEVELS = {
+  DANGER: { label: '위험', color: 'text-red-600', bg: 'bg-red-50', ring: 'ring-red-200' },
+  WARNING: { label: '주의', color: 'text-orange-500', bg: 'bg-orange-50', ring: 'ring-orange-200' },
+  NORMAL: { label: '보통', color: 'text-blue-600', bg: 'bg-blue-50', ring: 'ring-blue-200' },
+  GOOD: { label: '우수', color: 'text-emerald-600', bg: 'bg-emerald-50', ring: 'ring-emerald-200' },
+  EXCELLENT: { label: '최우수', color: 'text-violet-600', bg: 'bg-violet-50', ring: 'ring-violet-200' },
+};
+
+export function tempColor(temp) {
+  if (temp >= 40) return 'text-red-500';
+  if (temp >= 37.5) return 'text-orange-500';
+  return 'text-blue-500';
+}
+
+export function tempBg(temp) {
+  if (temp >= 40) return 'bg-red-500';
+  if (temp >= 37.5) return 'bg-orange-400';
+  return 'bg-blue-500';
+}
+
+export function trustMeta(level) {
+  return TRUST_LEVELS[level] || TRUST_LEVELS.NORMAL;
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,8 +4,15 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    // sockjs-client 가 Node 의 global 을 참조해 브라우저에서 흰 화면이 납니다
+    global: 'globalThis',
+  },
   server: {
     port: 3000,
+  },
+  optimizeDeps: {
+    include: ['sockjs-client', '@stomp/stompjs'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- WebSocket(STOMP) 파티 채팅 및 실시간 파티/알림 갱신
- 출발 10분 전·참여 등 인앱/브라우저 알림
- 출발 시간 기반 파티 상태 자동 전환 스케줄러
- 매너 온도·신뢰 대시보드, 멤버 평가, 노쇼 신고 및 이용 정지
- 로컬 H2 개발 프로필 및 gitignore 보강